### PR TITLE
gettimeofday portability

### DIFF
--- a/src/protocol/binary_messages.cpp
+++ b/src/protocol/binary_messages.cpp
@@ -142,7 +142,6 @@ namespace OpcUa
   {
     const int64_t secsFrom1600To1970 = 11676096000LL;
     int64_t t1 = (usec * 10) + (secsFrom1600To1970 * 10000000LL);
-
     return DateTime(t1);
   }
 


### PR DESCRIPTION
I was trying to make the code compile with visual studio 2013. This is one of the issues I ran into.
Rather than implementing a platform dependent workaround that mimics gettimeofday for windows, I replaced the code with platform independent chrono based code. 

(appologies for having 3 commits, it's the first time I created a pull request :-) 
compilation with visual studio is not working yet btw.
