### PR TITLE
close acceptor on exit

### DIFF
--- a/src/server/opc_tcp_async.cpp
+++ b/src/server/opc_tcp_async.cpp
@@ -334,6 +334,7 @@ namespace
   {
     std::clog << "opc_tcp_async| Shutdowning server." << std::endl;
     Clients.clear();
+    acceptor.close();
   }
 
   void OpcTcpServer::Accept()


### PR DESCRIPTION
this wont fix all the `bind: address already used` problems but definitely wont hurt.
- close acceptor on exit.
