### PR TITLE
Fix building errors while using libc++

### DIFF
--- a/src/client/binary_client.cpp
+++ b/src/client/binary_client.cpp
@@ -828,7 +828,7 @@ private:
 
 OpcUa::Services::SharedPtr OpcUa::CreateBinaryClient(OpcUa::IOChannel::SharedPtr channel, const OpcUa::SecureConnectionParams& params, bool debug)
 {
-  return OpcUa::Services::SharedPtr(new BinaryClient(channel, params, debug));
+  return std::make_shared<BinaryClient>(channel, params, debug);
 }
 
 OpcUa::Services::SharedPtr OpcUa::CreateBinaryClient(const std::string& endpointUrl, bool debug)

--- a/src/protocol/binary_serialization.h
+++ b/src/protocol/binary_serialization.h
@@ -11,6 +11,7 @@
 #ifndef __OPC_UA_BINARY_SERIALIZATION_TOOLS_H__
 #define __OPC_UA_BINARY_SERIALIZATION_TOOLS_H__
 
+#include <algorithm>
 #include <stdint.h>
 
 
@@ -19,15 +20,11 @@ namespace OpcUa
   template<class Stream, class Container>
   inline void SerializeContainer(Stream& out, const Container& c, uint32_t emptySizeValue = ~uint32_t())
   {
-    if (c.size() == 0)
-    {
+    if (c.empty()) {
       out.Serialize(emptySizeValue);
-      return;
-    }
-    out.Serialize((uint32_t)c.size());
-    for (auto it = c.begin(); it != c.end(); ++ it)
-    {
-      out.Serialize(*it);
+    } else {
+      out.Serialize(static_cast<uint32_t>(c.size()));
+      std::for_each(c.begin(), c.end(), [&](typename Container::value_type const& v) { out.Serialize(v); });
     }
   }
 

--- a/src/protocol/binary_serialization.h
+++ b/src/protocol/binary_serialization.h
@@ -20,9 +20,12 @@ namespace OpcUa
   template<class Stream, class Container>
   inline void SerializeContainer(Stream& out, const Container& c, uint32_t emptySizeValue = ~uint32_t())
   {
-    if (c.empty()) {
+    if (c.empty())
+    {
       out.Serialize(emptySizeValue);
-    } else {
+    }
+    else
+    {
       out.Serialize(static_cast<uint32_t>(c.size()));
       std::for_each(c.begin(), c.end(), [&](typename Container::value_type const& v) { out.Serialize(v); });
     }


### PR DESCRIPTION
- Constructor of std::shared_ptr in libc++ forbids implicitly
upcasting. Replace constructor with std::make_shared.
- Dereference type of iterator of std::vector<bool> is not bool in
libc++.