### PR TITLE
Break ByteStrings into concatenated lines

### DIFF
--- a/schemas/generate_address_space.py
+++ b/schemas/generate_address_space.py
@@ -181,8 +181,9 @@ namespace OpcUa
                     elif ntag == "UInt32":
                         obj.value.append("(uint32_t) " + val.text)
                     elif ntag in ('ByteString', 'String'):
-                        mytext = val.text.replace('\n', '').replace('\r', '')
-                        obj.value.append('+"{}"'.format(mytext))
+                        mytext = ['"{}"'.format(x) for x in val.text.replace('\r', '').splitlines()]
+                        mytext = '\n'.join(mytext)
+                        obj.value.append('+{}'.format(mytext))
                     elif ntag == "ListOfExtensionObject":
                         pass
                     elif ntag == "ListOfLocalizedText":


### PR DESCRIPTION
This avoids the limit in VC++ that string literals can only be about 2k long - preprocessor-concatenated strings can be up to 65k.