### PR TITLE
Continuation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,8 +202,7 @@ SET(opcuacore_SOURCES
 add_library(opcuacore STATIC ${opcuacore_SOURCES})
 
 target_compile_options(opcuacore PUBLIC ${STATIC_LIBRARY_CXX_FLAGS})
-target_link_libraries(opcuacore ${ADDITIONAL_LINK_LIBRARIES} opcuaprotocol
-${Boost_LIBRARIES})
+target_link_libraries(opcuacore ${ADDITIONAL_LINK_LIBRARIES} opcuaprotocol)
 
 if (BUILD_TESTING)
     add_library(test_dynamic_addon MODULE
@@ -255,7 +254,6 @@ if (BUILD_CLIENT)
     target_link_libraries(opcuaclient 
         opcuacore 
         ${ADDITIONAL_LINK_LIBRARIES} 
-        ${Boost_LIBRARIES}
         )
 
     #tests/client/binary_handshake.cpp
@@ -283,7 +281,6 @@ if (BUILD_CLIENT)
         ${ADDITIONAL_LINK_LIBRARIES}
         opcuaprotocol
         opcuacore
-        ${Boost_LIBRARIES}
     )
 
     target_compile_options(opcuaclient PUBLIC ${EXECUTABLE_CXX_FLAGS})
@@ -409,7 +406,6 @@ if(BUILD_SERVER)
         opcuaprotocol
         opcuacore
         opcuaserver
-        ${Boost_LIBRARIES}
         )
     target_compile_options(opcuaserverapp PUBLIC ${EXECUTABLE_CXX_FLAGS})
 
@@ -429,7 +425,6 @@ if (BUILD_CLIENT)
         opcuaprotocol
         opcuacore
         opcuaclient
-        ${Boost_LIBRARIES}
     )
 
     target_compile_options(example_client PUBLIC ${EXECUTABLE_CXX_FLAGS})
@@ -450,7 +445,6 @@ if(BUILD_SERVER)
     opcuaprotocol
     opcuacore
     opcuaserver
-    ${Boost_LIBRARIES}
     )
 
     target_compile_options(example_server PUBLIC ${EXECUTABLE_CXX_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,10 @@ add_library(opcuaprotocol STATIC
 target_compile_options(opcuaprotocol PUBLIC ${STATIC_LIBRARY_CXX_FLAGS})
 target_link_libraries(opcuaprotocol ${ADDITIONAL_LINK_LIBRARIES})
 
+if (NOT WIN32)
+    target_link_libraries(opcuaprotocol ${Boost_LIBRARIES})
+endif ()
+
 if (BUILD_TESTING)
     add_executable(test_opcuaprotocol
         tests/protocol/binary_deserialize.cpp

--- a/src/client/binary_client.cpp
+++ b/src/client/binary_client.cpp
@@ -567,6 +567,7 @@ namespace
       request.Header = CreateRequestHeader();
       request.Query = query;
       const BrowseResponse response = Send<BrowseResponse>(request);
+      ContinuationPoints.clear();
       for ( BrowseResult result : response.Results )
       {
         if (! result.ContinuationPoint.empty())
@@ -591,6 +592,14 @@ namespace
       request.ReleaseContinuationPoints = ContinuationPoints.empty() ? true: false;
       request.ContinuationPoints = ContinuationPoints;
       const BrowseNextResponse response = Send<BrowseNextResponse>(request);
+      ContinuationPoints.clear();
+      for ( auto result : response.Results )
+      {
+      	if (! result.ContinuationPoint.empty())
+	{
+	  ContinuationPoints.push_back(result.ContinuationPoint);
+	}
+      }
       if (Debug)  { std::cout << "binary_client| BrowseNext <--" << std::endl; }
       return response.Results;
     }

--- a/src/core/subscription.cpp
+++ b/src/core/subscription.cpp
@@ -40,7 +40,7 @@ namespace OpcUa
 
   void Subscription::Delete()
   {
-    std::vector<StatusCode> results = Server->Subscriptions()->DeleteSubscriptions(std::vector<uint32_t>({Data.SubscriptionId}));
+    std::vector<StatusCode> results = Server->Subscriptions()->DeleteSubscriptions(std::vector<uint32_t>{Data.SubscriptionId});
     for (auto res: results)
     {
       CheckStatusCode(res);


### PR DESCRIPTION
As discussed in #153, this branch contains a fix for browsing server nodes with over 100 children through continuation lists.

It also contains another fix for CMakeLists.txt to build on Windows under MSVC 12.0.  As it was, the build failed with multiply-defined boost symbols (because the Boost libraries were all included on the link commandline twice).  I've checked that the fix also builds on Ubuntu 14.04 amd64.