### PR TITLE
Adds a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:jessie
+MAINTAINER Beau Trepp <https://github.com/btrepp>
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get clean && apt-get update && apt-get install -y \
+ gcc \
+ g++ \
+ make \
+ autoconf \
+ automake \
+ libtool \
+ libboost-dev \
+ libboost-thread-dev \
+ libboost-program-options-dev \
+ libboost-system-dev \
+ libboost-filesystem-dev \
+ libcppunit-dev \
+ pkg-config git \
+ python-dev \
+ libboost-python-dev \
+ gsoap \
+ libxml2-dev \
+ build-essential \
+ autotools-dev \
+ dh-make \
+ debhelper \
+ devscripts \
+ fakeroot \
+ xutils \
+ lintian \
+ pbuilder \
+ reprepro
+ADD / /tmp/freeopcua
+WORKDIR /tmp/freeopcua
+RUN ./build.sh
+RUN make check
+RUN make install

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ ctest -C Debug
 cd bin\Debug
 example_server.exe
 ```
+
+#### Docker
+
+```
+docker build -f docker/Dockerfile .
+```
+
 ## Developement
 
 C++ style


### PR DESCRIPTION
This allows you to build freeopcua in a debian-jessie docker image. Installs dependencies via apt-get
and runs the build.sh script.

Result should be a docker container with the freeopcua libraries built and installed. Useful for developing and for basing tools that use freeopcua off of.