### PR TITLE
Add minimal cmake definitions to enable deb builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,4 +478,6 @@ if (BUILD_PYTHON)
     add_subdirectory (python)
 endif (BUILD_PYTHON)
 
-
+SET(CPACK_GENERATOR "DEB")
+SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "FreeOpcUa")
+INCLUDE(CPack)


### PR DESCRIPTION
This allows you to create quick and dirty deb packages using cmake && make && cpack