### PR TITLE
#171: BinaryClient callback thread is not stopped when client disconn…

### DIFF
--- a/include/opc/ua/client/client.h
+++ b/include/opc/ua/client/client.h
@@ -92,8 +92,13 @@ namespace OpcUa
     void Connect(const EndpointDescription&);
 
     /// @brief Disconnect from server
-    // close all threads and subcsriptions
-    void Disconnect();
+    // close communication with OPC-UA server, close all threads and subcsriptions
+    void Disconnect(bool abort = false);
+
+    /// @brief Abort server connection
+    // abort communication with OPC-UA server, close all threads and subcsriptions
+    // Like Disconnect() but without CloseSession() call, which is not possible on faulty connection anyway
+    void Abort() {Disconnect(true);}
 
     /// @brief  Connect to server and get endpoints
     std::vector<EndpointDescription> GetServerEndpoints(const std::string& endpoint);

--- a/include/opc/ua/services/services.h
+++ b/include/opc/ua/services/services.h
@@ -46,6 +46,7 @@ namespace OpcUa
     virtual CreateSessionResponse CreateSession(const RemoteSessionParameters& parameters) = 0;
     virtual ActivateSessionResponse ActivateSession(const UpdatedSessionParameters &session_parameters) = 0;
     virtual CloseSessionResponse CloseSession() = 0;
+    virtual void AbortSession() = 0;
 
     virtual EndpointServices::SharedPtr Endpoints() = 0;
     virtual ViewServices::SharedPtr Views() = 0;

--- a/src/client/binary_client.cpp
+++ b/src/client/binary_client.cpp
@@ -230,7 +230,7 @@ namespace
       ReceiveThread.join();
       if (Debug) std::cout << "binary_client| Receive tread stopped." << std::endl;
 
-
+      if (Debug) std::cout << "binary_client| Destroyed." << std::endl;
     }
 
     virtual CreateSessionResponse CreateSession(const RemoteSessionParameters& parameters)
@@ -276,8 +276,16 @@ namespace
       if (Debug)  { std::cout << "binary_client| CloseSession -->" << std::endl; }
       CloseSessionRequest request;
       CloseSessionResponse response = Send<CloseSessionResponse>(request);
+      RemoveSelfReferences();
       if (Debug)  { std::cout << "binary_client| CloseSession <--" << std::endl; }
       return response;
+    }
+
+    virtual void AbortSession()
+    {
+      if (Debug)  { std::cout << "binary_client| AbortSession -->" << std::endl; }
+      RemoveSelfReferences();
+      if (Debug)  { std::cout << "binary_client| AbortSession <--" << std::endl; }
     }
 
     virtual std::shared_ptr<EndpointServices> Endpoints() override
@@ -378,6 +386,14 @@ namespace
     {
       ContinuationPoints.clear();
       BrowseNext();
+    }
+
+    // Binary client is self-referenced from captures of subscription callbacks
+    // Remove this references to make ~BinaryClient() run possible
+    void RemoveSelfReferences()
+    {
+      if (Debug)  { std::cout << "binary_client| Clearing cached references to server" << std::endl; }
+      PublishCallbacks.clear();
     }
 
   public:

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -268,15 +268,22 @@ namespace OpcUa
     Disconnect();//Do not leave any thread or connectino running
   } 
 
-  void UaClient::Disconnect()
+  void UaClient::Disconnect(bool abort)
   {
     KeepAlive.Stop();
     KeepAlive.Join();
 
     if (  Server ) 
     {
-      CloseSessionResponse response = Server->CloseSession();
-      if (Debug) { std::cout << "CloseSession response is " << ToString(response.Header.ServiceResult) << std::endl; }
+      if ( abort )
+      {
+        Server->AbortSession();
+      }
+      else
+      {
+        CloseSessionResponse response = Server->CloseSession();
+        if (Debug) { std::cout << "CloseSession response is " << ToString(response.Header.ServiceResult) << std::endl; }
+      }
       CloseSecureChannel();
     }
     Server.reset(); //FIXME: check if we still need this

--- a/src/server/services_registry_impl.cpp
+++ b/src/server/services_registry_impl.cpp
@@ -178,6 +178,10 @@ namespace
       return CloseSessionResponse();
     }
 
+    virtual void AbortSession()
+    {
+    }
+
     virtual EndpointServices::SharedPtr Endpoints() override
     {
       return EndpointsServices;


### PR DESCRIPTION
…ected.

* Service self-reference fixed
* UaClient::Abort() added to abort faulty connection (without CloseSession)
  call, which is not possible anyway