### PR TITLE
#171: BinaryClient callback thread is not stopped when client disconn…

### DIFF
--- a/include/opc/ua/client/client.h
+++ b/include/opc/ua/client/client.h
@@ -92,8 +92,13 @@ namespace OpcUa
     void Connect(const EndpointDescription&);
 
     /// @brief Disconnect from server
-    // close all threads and subscriptions
-    void Disconnect();
+    // close communication with OPC-UA server, close all threads and subscriptions
+    void Disconnect(bool abort = false);
+
+    /// @brief Abort server connection
+    // abort communication with OPC-UA server, close all threads and subcsriptions
+    // Like Disconnect() but without CloseSession() call, which is not possible on faulty connection anyway
+    void Abort() {Disconnect(true);}
 
     /// @brief  Connect to server and get endpoints
     std::vector<EndpointDescription> GetServerEndpoints(const std::string& endpoint);

--- a/include/opc/ua/services/services.h
+++ b/include/opc/ua/services/services.h
@@ -49,6 +49,7 @@ namespace OpcUa
     virtual CreateSessionResponse CreateSession(const RemoteSessionParameters& parameters) = 0;
     virtual ActivateSessionResponse ActivateSession(const ActivateSessionParameters &session_parameters) = 0;
     virtual CloseSessionResponse CloseSession() = 0;
+    virtual void AbortSession() = 0;
 
     virtual AttributeServices::SharedPtr Attributes() = 0;
     virtual EndpointServices::SharedPtr Endpoints() = 0;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -269,14 +269,21 @@ namespace OpcUa
     Disconnect();//Do not leave any thread or connectino running
   } 
 
-  void UaClient::Disconnect()
+  void UaClient::Disconnect(bool abort)
   {
     KeepAlive.Stop();
 
     if (  Server ) 
     {
-      CloseSessionResponse response = Server->CloseSession();
-      if (Debug) { std::cout << "CloseSession response is " << ToString(response.Header.ServiceResult) << std::endl; }
+      if ( abort )
+      {
+        Server->AbortSession();
+      }
+      else
+      {
+        CloseSessionResponse response = Server->CloseSession();
+        if (Debug) { std::cout << "CloseSession response is " << ToString(response.Header.ServiceResult) << std::endl; }
+      }
       CloseSecureChannel();
     }
     Server.reset(); //FIXME: check if we still need this

--- a/src/server/services_registry_impl.cpp
+++ b/src/server/services_registry_impl.cpp
@@ -196,6 +196,10 @@ namespace
       return CloseSessionResponse();
     }
 
+    virtual void AbortSession()
+    {
+    }
+
     virtual EndpointServices::SharedPtr Endpoints() override
     {
       return EndpointsServices;


### PR DESCRIPTION
…ected.

* Service self-reference fixed
* UaClient::Abort() added to abort faulty connection (without CloseSession)
  call, which is not possible anyway