### PR TITLE
fixed bug in UaClient::Connect with username & password

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -162,7 +162,19 @@ namespace OpcUa
   void UaClient::Connect(const std::string& endpoint)
   {
     EndpointDescription endpointdesc = SelectEndpoint(endpoint);
-    endpointdesc.EndpointUrl = endpoint; //force the use of the enpoint the user wants, seems like servers often send wrong hostname
+    
+    //force the use of the enpoint the user wants, seems like servers often send wrong hostname
+    //if there is a username:password in endpoint it has to be removed
+    std::size_t begin = endpoint.find("//");
+    std::size_t end = endpoint.rfind("@");
+    if (begin < end) 
+    {
+      endpointdesc.EndpointUrl = endpoint.replace(begin+2, end - begin - 1, "");
+    }  
+    else 
+    {
+      endpointdesc.EndpointUrl = endpoint; 
+    }
     Connect(endpointdesc);
   }
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -165,15 +165,11 @@ namespace OpcUa
     
     //force the use of the enpoint the user wants, seems like servers often send wrong hostname
     //if there is a username:password in endpoint it has to be removed
-    std::size_t begin = endpoint.find("//");
-    std::size_t end = endpoint.rfind("@");
-    if (begin < end) 
+    std::size_t begin = endpointdesc.EndpointUrl.find("//");
+    std::size_t end = endpointdesc.EndpointUrl.rfind("@");
+    if (begin < end)
     {
-      endpointdesc.EndpointUrl = endpoint.replace(begin+2, end - begin - 1, "");
-    }  
-    else 
-    {
-      endpointdesc.EndpointUrl = endpoint; 
+      endpointdesc.EndpointUrl.replace(begin+2, end - begin - 1, "");
     }
     Connect(endpointdesc);
   }


### PR DESCRIPTION
Enforcing the given endpoint would not work with username and password.
You could also change the call sig to remove the else clause. 