### PR TITLE
Fixing a crash scenario where the condition_variable gets timeout

### DIFF
--- a/src/client/binary_client.cpp
+++ b/src/client/binary_client.cpp
@@ -520,7 +520,6 @@ namespace
 					catch (const std::exception& ex)
 					{
 						std::cout << "Error calling application callback " << ex.what() << std::endl;
-						throw ex;
 					}
 				}
 			}

--- a/src/client/binary_client.cpp
+++ b/src/client/binary_client.cpp
@@ -97,7 +97,7 @@ namespace
     T WaitForData(std::chrono::milliseconds msec)
     {
 	  if (doneEvent.wait_for(lock, msec) == std::cv_status::timeout)
-		  throw std::exception("Response timed out");
+		  throw std::runtime_error("Response timed out");
 
       T result;
 	  result.Header = std::move(this->header);

--- a/src/client/binary_client.cpp
+++ b/src/client/binary_client.cpp
@@ -741,7 +741,7 @@ private:
 
 	  Response res;
 	  try {
-      return requestCallback.WaitForData(std::chrono::milliseconds(request.Header.Timeout));
+      res = requestCallback.WaitForData(std::chrono::milliseconds(request.Header.Timeout));
 	  }
 	  catch (std::exception &ex)
 	  {

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -87,6 +87,7 @@ namespace OpcUa
     catch (std::system_error ex)
     {
       if (Debug) { std::cout << "KeepaliveThread | Exception thrown at attempt to join: " << ex.what() << std::endl; }
+	  throw ex;
     }
   }
 


### PR DESCRIPTION
**File:** binary_client.cpp, 
**method:** Response Send(Request request) const (Line#733)
**Issue:** requestCallback is created on the stack and is being added to Callbacks. 
There is no proper cleanup when the condition_variable (doneEvent) gets timeout. The above created requestCallback should be removed from the Callbacks. Leaving it is causing SEG FAULTS.
**How to reproduce:** This could be easily duplicated by reducing the WaitForData time.
**Fix:** Identify the condition_variable timeout and throw a standard exception. Send(...) method should be changed to catch exception and remove the requestHandle from Callbacks.
Also, added code to propagate the exception. So that the client application can better handle them.
