### PR TITLE
Closing the socket to avoid handle leak

### DIFF
--- a/src/client/binary_connection.cpp
+++ b/src/client/binary_connection.cpp
@@ -58,6 +58,11 @@ namespace
     int error = connect(sock, (sockaddr*)& addr, sizeof(addr));
     if (error < 0)
     {
+#ifdef _WIN32
+			closesocket(sock);
+#else
+			close(sock);
+#endif
       THROW_OS_ERROR(std::string("Unable connect to host '") + host + std::string("'. "));
     }
     return sock;


### PR DESCRIPTION
A simple scenario where the application is watching the connection state and trying to reconnect, if it is not. Noticed an handle leak, if the OPC server is not available or given wrong ip/host.