### PR TITLE
Add variant-deserialization for ExtensionObject

### DIFF
--- a/src/protocol/binary_variant.cpp~
+++ b/src/protocol/binary_variant.cpp~
@@ -16,7 +16,6 @@
 #include <opc/ua/protocol/types.h>
 #include <opc/ua/protocol/variant.h>
 #include <opc/ua/protocol/variant_visitor.h>
-#include <opc/ua/protocol/protocol_auto.h>
 
 #include <algorithm>
 #include <functional>


### PR DESCRIPTION
De-serializing for ExtensionObject is already implemented, this PR only adds the functionality to Variants. This fixes the issue I asked about [on the mailing list ](https://groups.google.com/forum/#!topic/freeopcua/7jHdQnXaVtM).

I only built with cmake on Ubuntu 16.4 and tested with a Beckhoff server.

There is arguably a larger issue behind the problem I had:

* The exception (previously) thrown in binary_variant.cpp is caught in binary_client.cpp Send(). It never reaches the user.
* Send() returns an empty result, instead of propagating the error.
* Node::GetAttribute() then returns a default DataValue, which is null.
