### PR TITLE
More fixes for older context (RHEL/CentOS 6)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,8 +27,6 @@ AC_ARG_ENABLE([gcov],
                 AC_SUBST([GCOV_FLAGS], ["-fprofile-arcs -ftest-coverage"])
                 AC_SUBST([GCOV_LIBS], [-lgcov])
                 AC_MSG_NOTICE([Enabled support of code coverage analysis.])
-              ],
-              [
               ])
 
 AC_ARG_ENABLE([python-bindings],

--- a/configure.ac
+++ b/configure.ac
@@ -22,11 +22,11 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADER([config.h])
 
 AC_ARG_ENABLE([gcov],
-              [AS_HELP_STRING([--enable-gcov],[Enable support of coverage analize with gcov.])],
+              [AS_HELP_STRING([--enable-gcov],[Enable support of coverage analysis with gcov.])],
               [
                 AC_SUBST([GCOV_FLAGS], ["-fprofile-arcs -ftest-coverage"])
                 AC_SUBST([GCOV_LIBS], [-lgcov])
-                AC_MSG_NOTICE([Enabled support of code coverage analize.])
+                AC_MSG_NOTICE([Enabled support of code coverage analysis.])
               ],
               [
               ])

--- a/python/setup.py
+++ b/python/setup.py
@@ -27,7 +27,7 @@ library_dirs = [
   os.path.join(opcua_server_path,'lib'),
 ]
 
-boost_library='boost_python3' if sys.version_info.major == 3 and platform.dist()[0] == 'fedora' else 'boost_python'
+boost_library='boost_python3' if sys.version_info[0] == 3 and platform.dist()[0] == 'fedora' else 'boost_python'
 
 libraries = [
   boost_library,
@@ -35,7 +35,7 @@ libraries = [
   'opcuaserver',
 ]
 
-if sys.version_info.major == 2: name='python-freeopcua'
+if sys.version_info[0] == 2: name='python-freeopcua'
 else: name='python{}-freeopcua'.format(sys.version_info.major)
 
 setup(name=name,


### PR DESCRIPTION
One more autoconf related fix (showed up when building without enabling gcov):
The empty 'else' part of AC_ARG_ENABLE was creating an empty 'else' part in the .configure script, which in turn lead to
```
[...]
./configure: line 15398: syntax error near unexpected token `fi'
./configure: line 15398: `fi'
```
Plus a fix in setup.py for python < 2.7 - before that the named elements of the sys.version_info tuple did not exist.

With these changes, I can build and successfully test freeOpcUa on RHEL 6.5 using devtoolset-3 (The [RedHat Developer Toolset](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-3/) providing recent GNU compilers), after upgrading boost to 1.48, adding the compatibility link `libboost_thread.so -> libboost_thread-mt.so` and installing cppunit-devel.