### PR TITLE
Re-throw exceptions caught in client Send()

### DIFF
--- a/src/client/binary_client.cpp
+++ b/src/client/binary_client.cpp
@@ -757,6 +757,7 @@ private:
 		  std::unique_lock<std::mutex> lock(Mutex);
 		  Callbacks.erase(request.Header.RequestHandle);
 		  lock.unlock();
+		  throw;
 	  }
 
 	  return res;


### PR DESCRIPTION
Errors get propagated to the user, instead of returning a default `Variant` which will behave unexpectedly.

Previously, Send() returned an empty result, when an exception was caught (e.g. network disconnect). This caused confusing behavior. E.g. I tried to poll ServerState without network connection and the error showed up as boost::bad_anycast, when I tried to convert the returned default Variant to int32.