### PR TITLE
skip used NodeId's

### DIFF
--- a/src/server/address_space_internal.cpp
+++ b/src/server/address_space_internal.cpp
@@ -572,13 +572,11 @@ namespace OpcUa
     {
       if (id == ObjectId::Null || id.IsNull())
       {
-        return OpcUa::NumericNodeId(++MaxNodeIdNum, DefaultIdx);
         return CreateUniqueNodeId(DefaultIdx);
       }
 
       if (id.HasNullIdentifier())
       {
-        return OpcUa::NumericNodeId(++MaxNodeIdNum, id.GetNamespaceIndex());
         return CreateUniqueNodeId(id.GetNamespaceIndex());
       }
 

--- a/src/server/address_space_internal.cpp
+++ b/src/server/address_space_internal.cpp
@@ -583,12 +583,22 @@ namespace OpcUa
         }
       }
 
+      // skip over already assigned node id's
+      // this should be a very seldom operation - it only happens when
+      // we actively assign static node id's to some nodes and after that
+      // create nodes using automatic id allocation and even then it
+      // only happens once. So we don't care about optimiziation here.
       for (;;)
       {
         NodeId result = OpcUa::NumericNodeId(++MaxNodeIdNum, idx);
         if (Nodes.find(result) == Nodes.end())
         {
           return result;
+        }
+        // completly unlikly - we would have to allocate 4gig nodes to
+        // fullfill this condition
+        if (MaxNodeIdNum == std::numeric_limits<uint32_t>::max()) {
+          throw std::runtime_error("AddressSpaceInternal | unable to assign new NodeId: range exceeded");
         }
       }
     }

--- a/src/server/address_space_internal.cpp
+++ b/src/server/address_space_internal.cpp
@@ -573,14 +573,28 @@ namespace OpcUa
       if (id == ObjectId::Null || id.IsNull())
       {
         return OpcUa::NumericNodeId(++MaxNodeIdNum, DefaultIdx);
+        return CreateUniqueNodeId(DefaultIdx);
       }
 
       if (id.HasNullIdentifier())
       {
         return OpcUa::NumericNodeId(++MaxNodeIdNum, id.GetNamespaceIndex());
+        return CreateUniqueNodeId(id.GetNamespaceIndex());
       }
 
       return id;
+    }
+
+    NodeId AddressSpaceInMemory::CreateUniqueNodeId(uint32_t idx)
+    {
+      for (;;)
+      {
+        NodeId result = OpcUa::NumericNodeId(++MaxNodeIdNum, idx);
+        if (Nodes.find(result) == Nodes.end())
+        {
+          return result;
+        }
+      }
     }
   }
 

--- a/src/server/address_space_internal.cpp
+++ b/src/server/address_space_internal.cpp
@@ -570,21 +570,19 @@ namespace OpcUa
 
     NodeId AddressSpaceInMemory::GetNewNodeId(const NodeId& id)
     {
+      uint32_t idx;
       if (id == ObjectId::Null || id.IsNull())
       {
-        return CreateUniqueNodeId(DefaultIdx);
+        idx = DefaultIdx;
+      } else {
+        if (id.HasNullIdentifier())
+        {
+          idx = id.GetNamespaceIndex();
+        } else {
+          return id;
+        }
       }
 
-      if (id.HasNullIdentifier())
-      {
-        return CreateUniqueNodeId(id.GetNamespaceIndex());
-      }
-
-      return id;
-    }
-
-    NodeId AddressSpaceInMemory::CreateUniqueNodeId(uint32_t idx)
-    {
       for (;;)
       {
         NodeId result = OpcUa::NumericNodeId(++MaxNodeIdNum, idx);

--- a/src/server/address_space_internal.h
+++ b/src/server/address_space_internal.h
@@ -122,7 +122,6 @@ namespace OpcUa
         AddNodesResult AddNode( const AddNodesItem& item );
         StatusCode AddReference(const AddReferencesItem& item);
         NodeId GetNewNodeId(const NodeId& id);
-        NodeId CreateUniqueNodeId(uint32_t idx);
         CallMethodResult CallMethod(CallMethodRequest method);
 
       private:

--- a/src/server/address_space_internal.h
+++ b/src/server/address_space_internal.h
@@ -122,6 +122,7 @@ namespace OpcUa
         AddNodesResult AddNode( const AddNodesItem& item );
         StatusCode AddReference(const AddReferencesItem& item);
         NodeId GetNewNodeId(const NodeId& id);
+        NodeId CreateUniqueNodeId(uint32_t idx);
         CallMethodResult CallMethod(CallMethodRequest method);
 
       private:


### PR DESCRIPTION
When you create a Node with an explicitly set NodeId - lets say 2003 -
and after that create three Node's using the automatic id allocation,
you run into error stating "NodeId 2003 already exists". This patch
avoids such errors by skipping existing NodeId's in automatic id
allocation.

Based this patch on the last official commit instead on my current working version - hope it is better this way.