### PR TITLE
fix use after free

### DIFF
--- a/src/server/internal_subscription.cpp
+++ b/src/server/internal_subscription.cpp
@@ -35,6 +35,13 @@ void InternalSubscription::Stop()
 {
   DeleteAllMonitoredItems();
   Timer.cancel();
+  {
+    boost::shared_lock<boost::shared_mutex> lock(DbMutex);
+    // after Stop() the callback is useless or - as Stop is part
+    // of the shutdown sequence of OpcTcpConnection - points to
+    // a no longer existing instance of OpcTcpMessages.
+    Callback = NULL;
+  }
 }
 
 void InternalSubscription::DeleteAllMonitoredItems()

--- a/src/server/internal_subscription.cpp
+++ b/src/server/internal_subscription.cpp
@@ -98,15 +98,17 @@ void InternalSubscription::PublishResults(const boost::system::error_code & erro
         {
           if (Debug) { std::cout << "InternalSubscription | Subscription has " << results.size() << " results, calling callback" << std::endl; }
 
-          if (Callback)
-            {
-              Callback(results[0]);
-            }
-
-          else
-            {
-              if (Debug) { std::cout << "InternalSubscription | No callback defined for this subscription" << std::endl; }
-            }
+          {
+            boost::shared_lock<boost::shared_mutex> lock(DbMutex);
+            if (Callback)
+              {
+                Callback(results[0]);
+              }
+            else
+              {
+                if (Debug) { std::cout << "InternalSubscription | No callback defined for this subscription" << std::endl; }
+              }
+          }
         }
     }
 


### PR DESCRIPTION
InternalSubscription::Callback is usually set to a lambda of an instance of OpcTcpMessages. On shutdown of OpcTcpConnection this instance is deleted while InternalSubscription is still used. Clear Callback on Stop() to make sure no access to this deleted instance takes place.