### PR TITLE
avoid use after free in OpcTcpMessages

### DIFF
--- a/include/opc/ua/protocol/channel.h
+++ b/include/opc/ua/protocol/channel.h
@@ -15,6 +15,8 @@
 #include <memory>
 #include <system_error>
 
+#include <opc/common/class_pointers.h>
+
 namespace OpcUa
 {
 
@@ -35,8 +37,7 @@ public:
 class InputChannel : public virtual BreakableChannel
 {
 public:
-  typedef std::shared_ptr<InputChannel> SharedPtr;
-  typedef std::unique_ptr<InputChannel> UniquePtr;
+  DEFINE_CLASS_POINTERS(InputChannel)
 
 public:
   virtual ~InputChannel() {}
@@ -57,8 +58,7 @@ public:
 class OutputChannel : public virtual BreakableChannel
 {
 public:
-  typedef std::shared_ptr<OutputChannel> SharedPtr;
-  typedef std::unique_ptr<OutputChannel> UniquePtr;
+  DEFINE_CLASS_POINTERS(OutputChannel)
 
 public:
   virtual ~OutputChannel() {}
@@ -78,8 +78,7 @@ class IOChannel :
   public OutputChannel
 {
 public:
-  typedef std::shared_ptr<IOChannel> SharedPtr;
-  typedef std::unique_ptr<IOChannel> UniquePtr;
+  DEFINE_CLASS_POINTERS(IOChannel)
 };
 
 }

--- a/src/server/opc_tcp_processor.h
+++ b/src/server/opc_tcp_processor.h
@@ -22,10 +22,13 @@ namespace OpcUa
 namespace Server
 {
 
-class OpcTcpMessages
+class OpcTcpMessages: public std::enable_shared_from_this<OpcTcpMessages>
 {
 public:
-  OpcTcpMessages(std::shared_ptr<OpcUa::Services> computer, OpcUa::OutputChannel & outputChannel, bool debug);
+  DEFINE_CLASS_POINTERS(OpcTcpMessages)
+
+public:
+  OpcTcpMessages(OpcUa::Services::SharedPtr server, OpcUa::OutputChannel::SharedPtr outputChannel, bool debug);
   ~OpcTcpMessages();
 
   bool ProcessMessage(Binary::MessageType msgType, Binary::IStreamBinary & iStream);
@@ -42,7 +45,8 @@ private:
 
 private:
   std::mutex ProcessMutex;
-  std::shared_ptr<OpcUa::Services> Server;
+  OpcUa::Services::SharedPtr Server;
+  OpcUa::OutputChannel::WeakPtr OutputChannel;
   OpcUa::Binary::OStreamBinary OutputStream;
   bool Debug;
   uint32_t ChannelId;

--- a/src/server/opcua_protocol_addon.cpp
+++ b/src/server/opcua_protocol_addon.cpp
@@ -54,7 +54,7 @@ public:
 
     if (Debug) { std::clog << "opc_tcp_processor| Hello client!" << std::endl; }
 
-    std::unique_ptr<OpcTcpMessages> messageProcessor(new OpcTcpMessages(Server, *clientChannel, Debug));
+    std::unique_ptr<OpcTcpMessages> messageProcessor(new OpcTcpMessages(Server, clientChannel, Debug));
 
     for (;;)
       {

--- a/src/server/opcua_protocol_addon.cpp
+++ b/src/server/opcua_protocol_addon.cpp
@@ -54,7 +54,7 @@ public:
 
     if (Debug) { std::clog << "opc_tcp_processor| Hello client!" << std::endl; }
 
-    std::unique_ptr<OpcTcpMessages> messageProcessor(new OpcTcpMessages(Server, clientChannel, Debug));
+    std::shared_ptr<OpcTcpMessages> messageProcessor = std::make_shared<OpcTcpMessages>(Server, clientChannel, Debug);
 
     for (;;)
       {


### PR DESCRIPTION
To avoid use of already deleted instances of OpcTcpMessages we make
it a shared_ptr instance itself, give outputChannel as a shared_ptr
instead of a reference and store outputChannel as a weak_ptr. We can now
make sure our OpcTcpMessages instance is still valid when we use it in
an async operation and check if the parent OpcTcpConnection (aka
OutputChannel) is still alive.

This patch is much more intrusive then the previously suggested hack
which simply deleted the subscription callback but it should be
much less fragile.