### PR TITLE
silence compiler warnings

### DIFF
--- a/src/client/binary_client.cpp
+++ b/src/client/binary_client.cpp
@@ -227,7 +227,7 @@ public:
 
     HelloServer(params);
 
-    ReceiveThread = std::move(std::thread([this]()
+    ReceiveThread = std::thread([this]()
     {
       try
         {
@@ -243,7 +243,7 @@ public:
 
           std::cerr << exc.what() << std::endl;
         }
-    }));
+    });
   }
 
   ~BinaryClient()

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -456,7 +456,7 @@ std::unique_ptr<Subscription> UaClient::CreateSubscription(unsigned int period, 
 
 ServerOperations UaClient::CreateServerOperations()
 {
-  return std::move(ServerOperations(Server));
+  return ServerOperations(Server);
 }
 } // namespace OpcUa
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -197,7 +197,7 @@ std::unique_ptr<Subscription> UaServer::CreateSubscription(unsigned int period, 
 
 ServerOperations UaServer::CreateServerOperations()
 {
-  return std::move(ServerOperations(Registry->GetServer()));
+  return ServerOperations(Registry->GetServer());
 }
 
 void UaServer::TriggerEvent(Event event)

--- a/src/server/server_object.cpp
+++ b/src/server/server_object.cpp
@@ -58,7 +58,7 @@ ServerObject::ServerObject(Services::SharedPtr services, boost::asio::io_service
   : Server(services)
   , Io(io)
   , Debug(debug)
-  , Instance(std::move(CreateServerObject(services)))
+  , Instance(CreateServerObject(services))
   , ServerTime(Instance.GetVariable(GetCurrentTimeRelativepath()))
   , Timer(io)
 {


### PR DESCRIPTION
beside some inconsistent override warnings this commit fixes these
pessimizing-move warnings:
./freeopcua/src/server/server.cpp:200:10: warning:
      moving a temporary object prevents copy elision [-Wpessimizing-move]
  return std::move(ServerOperations(Registry->GetServer()))\;
         ^
./freeopcua/src/server/server.cpp:200:10: note:
      remove std::move call here
  return std::move(ServerOperations(Registry->GetServer()))\;

         ^~~~~~~~~~                                       ~
./freeopcua/src/client/binary_client.cpp:230:21: warning:
      moving a temporary object prevents copy elision [-Wpessimizing-move]
    ReceiveThread = std::move(std::thread([this]()
                    ^
./freeopcua/src/client/binary_client.cpp:230:21: note:
      remove std::move call here
    ReceiveThread = std::move(std::thread([this]()
                    ^~~~~~~~~~