### PR TITLE
add SharedPtr/.. to Subscription

### DIFF
--- a/include/opc/ua/subscription.h
+++ b/include/opc/ua/subscription.h
@@ -89,6 +89,9 @@ public:
 class Subscription
 {
 public:
+  DEFINE_CLASS_POINTERS(Subscription)
+
+public:
   //Create a new subscription on server
   //methods of callback object will be called everytime an event is received from the server
   //FIXME: should we use interface or std::function for callback???? std::function syntax is ugly but is more flexible


### PR DESCRIPTION
Add DEFINE_CLASS_POINTERS to Subscription.

BTW: does it make sense to return a unique_ptr<Subscription> in UaClient::CreateSubscription(). A unique_ptr is highly unusable for further usage of the subscription instance. shared_ptr would be much more useful. 