### PR TITLE
use shared_ptr for CreateSubscription

### DIFF
--- a/include/opc/ua/client/client.h
+++ b/include/opc/ua/client/client.h
@@ -145,7 +145,7 @@ public:
   /// @brief Create a subscription objects
   // returned object can then be used to subscribe
   // to datachange or custom events from server
-  std::unique_ptr<Subscription> CreateSubscription(unsigned int period, SubscriptionHandler & client);
+  Subscription::SharedPtr CreateSubscription(unsigned int period, SubscriptionHandler & client);
 
   /// @brief Create a server operations object
   ServerOperations CreateServerOperations();
@@ -156,6 +156,7 @@ private:
 
   std::vector<OpcUa::Node> AddChilds(std::vector<OpcUa::Node> nodes);
 
+protected:
   EndpointDescription Endpoint;
   // defined some sensible defaults that should let us connect to most servers
   std::string SessionName = "Open source OPC-UA Client Session";
@@ -166,10 +167,7 @@ private:
   uint32_t SecureChannelId;
   bool Debug = false;
   uint32_t DefaultTimeout = 3600000;
-
-protected:
   Services::SharedPtr Server;
-
 };
 
 } // namespace OpcUa

--- a/include/opc/ua/server/server.h
+++ b/include/opc/ua/server/server.h
@@ -82,7 +82,7 @@ public:
   /// @brief Create a subscription objects
   // returned object can then be used to subscribe to
   // datachange or custom events on server side
-  std::unique_ptr<Subscription> CreateSubscription(unsigned int period, SubscriptionHandler & callback);
+  Subscription::SharedPtr CreateSubscription(unsigned int period, SubscriptionHandler & callback);
 
   /// @brief Create a server operations object
   ServerOperations CreateServerOperations();

--- a/include/opc/ua/subscription.h
+++ b/include/opc/ua/subscription.h
@@ -89,6 +89,9 @@ public:
 class Subscription
 {
 public:
+  DEFINE_CLASS_POINTERS(Subscription)
+
+public:
   //Create a new subscription on server
   //methods of callback object will be called everytime an event is received from the server
   //FIXME: should we use interface or std::function for callback???? std::function syntax is ugly but is more flexible

--- a/python/src/py_opcua_module.cpp
+++ b/python/src/py_opcua_module.cpp
@@ -244,8 +244,8 @@ static void Node_SetValue(Node & self, const object & obj, VariantType vtype)
 
 static boost::shared_ptr<Subscription> UaClient_CreateSubscription(UaClient & self, uint period, PySubscriptionHandler & callback)
 {
-  std::unique_ptr<Subscription> sub  = self.CreateSubscription(period, callback);
-  return boost::shared_ptr<Subscription>(sub.release());
+  Subscription::SharedPtr sub  = self.CreateSubscription(period, callback);
+  return boost::shared_ptr<Subscription>(sub.get());
 }
 
 static Node UaClient_GetNode(UaClient & self, ObjectId objectid)
@@ -259,8 +259,8 @@ static Node UaClient_GetNode(UaClient & self, ObjectId objectid)
 
 static boost::shared_ptr<Subscription> UaServer_CreateSubscription(UaServer & self, uint period, PySubscriptionHandler & callback)
 {
-  std::unique_ptr<Subscription> sub  = self.CreateSubscription(period, callback);
-  return boost::shared_ptr<Subscription>(sub.release());
+  Subscription::SharedPtr sub  = self.CreateSubscription(period, callback);
+  return boost::shared_ptr<Subscription>(sub.get());
 }
 
 static Node UaServer_GetNode(UaServer & self, ObjectId objectid)

--- a/python/src/py_opcua_module.cpp
+++ b/python/src/py_opcua_module.cpp
@@ -242,10 +242,16 @@ static void Node_SetValue(Node & self, const object & obj, VariantType vtype)
 // UaClient helpers
 //--------------------------------------------------------------------------
 
+template<typename T>
+boost::shared_ptr<T> make_shared_ptr(std::shared_ptr<T>& ptr)
+{
+    return boost::shared_ptr<T>(ptr.get(), [ptr](T*) mutable {ptr.reset();});
+}
+
 static boost::shared_ptr<Subscription> UaClient_CreateSubscription(UaClient & self, uint period, PySubscriptionHandler & callback)
 {
   Subscription::SharedPtr sub  = self.CreateSubscription(period, callback);
-  return boost::shared_ptr<Subscription>(sub.get());
+  return make_shared_ptr<Subscription>(sub);
 }
 
 static Node UaClient_GetNode(UaClient & self, ObjectId objectid)
@@ -260,7 +266,7 @@ static Node UaClient_GetNode(UaClient & self, ObjectId objectid)
 static boost::shared_ptr<Subscription> UaServer_CreateSubscription(UaServer & self, uint period, PySubscriptionHandler & callback)
 {
   Subscription::SharedPtr sub  = self.CreateSubscription(period, callback);
-  return boost::shared_ptr<Subscription>(sub.get());
+  return make_shared_ptr<Subscription>(sub);
 }
 
 static Node UaServer_GetNode(UaServer & self, ObjectId objectid)

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -446,12 +446,12 @@ std::vector<OpcUa::Node> UaClient::AddChilds(std::vector<OpcUa::Node> nodes)
   return results;
 }
 
-std::unique_ptr<Subscription> UaClient::CreateSubscription(unsigned int period, SubscriptionHandler & callback)
+Subscription::SharedPtr UaClient::CreateSubscription(unsigned int period, SubscriptionHandler & callback)
 {
   CreateSubscriptionParameters params;
   params.RequestedPublishingInterval = period;
 
-  return std::unique_ptr<Subscription>(new Subscription(Server, params, callback, Debug));
+  return std::make_shared<Subscription>(Server, params, callback, Debug);
 }
 
 ServerOperations UaClient::CreateServerOperations()

--- a/src/examples/example_client.cpp
+++ b/src/examples/example_client.cpp
@@ -96,7 +96,7 @@ int main(int argc, char ** argv)
 
       //Subscription
       SubClient sclt;
-      std::unique_ptr<Subscription> sub = client.CreateSubscription(100, sclt);
+      Subscription::SharedPtr sub = client.CreateSubscription(100, sclt);
       uint32_t handle = sub->SubscribeDataChange(myvar);
       std::cout << "Got sub handle: " << handle << ", sleeping 5 seconds" << std::endl;
       std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -187,12 +187,12 @@ void UaServer::EnableEventNotification()
   server.SetAttribute(AttributeId::EventNotifier, dval);
 }
 
-std::unique_ptr<Subscription> UaServer::CreateSubscription(unsigned int period, SubscriptionHandler & callback)
+Subscription::SharedPtr UaServer::CreateSubscription(unsigned int period, SubscriptionHandler & callback)
 {
   CheckStarted();
   CreateSubscriptionParameters params;
   params.RequestedPublishingInterval = period;
-  return std::unique_ptr<Subscription>(new Subscription(Registry->GetServer(), params, callback, Debug));
+  return std::make_shared<Subscription>(Registry->GetServer(), params, callback, Debug);
 }
 
 ServerOperations UaServer::CreateServerOperations()


### PR DESCRIPTION
  - add DEFINE_CLASS_POINTERS to Subscription
  - in python interface the unique_ptr of UaClient/UaServer has been
    converted to boost::shared_ptr anyway
  - make variables of UaClient protected  - and therefor derivable - as
    they are in UaServer