### PR TITLE
Get properties

### DIFF
--- a/include/opc/ua/node.h
+++ b/include/opc/ua/node.h
@@ -53,8 +53,10 @@ public:
   QualifiedName GetBrowseName() const;
   //void SetBrowseName(const QualifiedName& name) const;
 
-  /// @brief List childrenn nodes by specified reference
-  /// @return One or zero chilren nodes.
+  Node GetParent() const;
+
+  /// @brief List child nodes by specified reference
+  /// @return zero or more child nodes.
   std::vector<Node> GetChildren(const OpcUa::ReferenceId & refid) const;
 
   /// @brief Get ghildren by hierarchal referencies.
@@ -69,7 +71,7 @@ public:
   Node GetChild(const std::vector<std::string> & path) const;
   Node GetChild(const std::string & browsename) const ;
 
-  std::vector<Node> GetProperties() const {return GetChildren(OpcUa::ReferenceId::HasProperty);}
+  std::vector<Node> GetProperties() const;
   std::vector<Node> GetVariables() const {return GetChildren(OpcUa::ReferenceId::HasComponent);} //Not correct should filter by variable type
 
 
@@ -127,6 +129,11 @@ public:
 
   //FIXME: I need this to create a copy for python binding, another way?
   OpcUa::Services::SharedPtr GetServices() const {return Server;}
+
+protected:
+  // base function for GetChildren(), put found children into given nodes
+  // parameter
+  void _GetChildren(const OpcUa::ReferenceId & refid, std::vector<Node> & nodes) const;
 
 protected:
   OpcUa::Services::SharedPtr Server;

--- a/src/core/node.cpp
+++ b/src/core/node.cpp
@@ -291,6 +291,10 @@ std::vector<Node> Node::GetProperties() const
   _GetChildren(OpcUa::ReferenceId::HasProperty, result);
   Node parent = GetParent();
   while (!parent.GetId().IsNull()) {
+    if (parent.GetAttribute(AttributeId::NodeClass).Value.As<int32_t>() != static_cast<int32_t>(NodeClass::ObjectType))
+      {
+        return result;
+      }
     parent._GetChildren(OpcUa::ReferenceId::HasProperty, result);
     parent = parent.GetParent();
   }


### PR DESCRIPTION
Node::GetProperties returned only the properties defined in this very ObjectTypeNode. Derived properties were not returned. This has been a problem for me when I tried to subscribe to a non basic event type as it did select only the newly introduced properties of this event type but not the generic ones. 