### PR TITLE
getProperties() and some convenience stuff for Node

### DIFF
--- a/include/opc/ua/node.h
+++ b/include/opc/ua/node.h
@@ -86,13 +86,15 @@ public:
 
   // convenience methods for attributes
   void SetAccessLevel(VariableAccessLevel value) { SetAttribute(AttributeId::AccessLevel, DataValue(static_cast<uint8_t>(value))); }
-  VariableAccessLevel GetAccessLevel() { return static_cast<VariableAccessLevel>(GetAttribute(AttributeId::AccessLevel).Value.As<uint8_t>()); }
+  VariableAccessLevel GetAccessLevel() const { return static_cast<VariableAccessLevel>(GetAttribute(AttributeId::AccessLevel).Value.As<uint8_t>()); }
+  void SetDescription(const LocalizedText & value) { SetAttribute(AttributeId::Description, DataValue(value)); }
+  LocalizedText GetDescription() const { return GetAttribute(AttributeId::Description).Value.As<LocalizedText>(); }
   void SetUserAccessLevel(VariableAccessLevel value) { SetAttribute(AttributeId::UserAccessLevel, DataValue(static_cast<uint8_t>(value))); }
-  VariableAccessLevel GetUserAccessLevel() { return static_cast<VariableAccessLevel>(GetAttribute(AttributeId::UserAccessLevel).Value.As<uint8_t>()); }
+  VariableAccessLevel GetUserAccessLevel() const { return static_cast<VariableAccessLevel>(GetAttribute(AttributeId::UserAccessLevel).Value.As<uint8_t>()); }
   void SetUserWriteMask(AttributeWriteMask value) { SetAttribute(AttributeId::UserWriteMask, DataValue(static_cast<uint32_t>(value))); }
-  AttributeWriteMask GetUserWriteMask() { return static_cast<AttributeWriteMask>(GetAttribute(AttributeId::UserWriteMask).Value.As<uint32_t>()); }
+  AttributeWriteMask GetUserWriteMask() const { return static_cast<AttributeWriteMask>(GetAttribute(AttributeId::UserWriteMask).Value.As<uint32_t>()); }
   void SetWriteMask(AttributeWriteMask value) { SetAttribute(AttributeId::WriteMask, DataValue(static_cast<uint32_t>(value))); }
-  AttributeWriteMask GetWriteMask() { return static_cast<AttributeWriteMask>(GetAttribute(AttributeId::WriteMask).Value.As<uint32_t>()); }
+  AttributeWriteMask GetWriteMask() const { return static_cast<AttributeWriteMask>(GetAttribute(AttributeId::WriteMask).Value.As<uint32_t>()); }
 
   //Helper method to get/set VALUE attribute of a node (Not all nodes support VALUE attribute)
   Variant GetValue() const;

--- a/include/opc/ua/node.h
+++ b/include/opc/ua/node.h
@@ -84,6 +84,16 @@ public:
   void SetAttribute(AttributeId attr, const DataValue & dval) const;
   //std::vector<StatusCode> WriteAttrs(OpcUa::AttributeId attr, const Variant &val);
 
+  // convenience methods for attributes
+  void SetAccessLevel(VariableAccessLevel value) { SetAttribute(AttributeId::AccessLevel, DataValue(static_cast<uint8_t>(value))); }
+  VariableAccessLevel GetAccessLevel() { return static_cast<VariableAccessLevel>(GetAttribute(AttributeId::AccessLevel).Value.As<uint8_t>()); }
+  void SetUserAccessLevel(VariableAccessLevel value) { SetAttribute(AttributeId::UserAccessLevel, DataValue(static_cast<uint8_t>(value))); }
+  VariableAccessLevel GetUserAccessLevel() { return static_cast<VariableAccessLevel>(GetAttribute(AttributeId::UserAccessLevel).Value.As<uint8_t>()); }
+  void SetUserWriteMask(AttributeWriteMask value) { SetAttribute(AttributeId::UserWriteMask, DataValue(static_cast<uint32_t>(value))); }
+  AttributeWriteMask GetUserWriteMask() { return static_cast<AttributeWriteMask>(GetAttribute(AttributeId::UserWriteMask).Value.As<uint32_t>()); }
+  void SetWriteMask(AttributeWriteMask value) { SetAttribute(AttributeId::WriteMask, DataValue(static_cast<uint32_t>(value))); }
+  AttributeWriteMask GetWriteMask() { return static_cast<AttributeWriteMask>(GetAttribute(AttributeId::WriteMask).Value.As<uint32_t>()); }
+
   //Helper method to get/set VALUE attribute of a node (Not all nodes support VALUE attribute)
   Variant GetValue() const;
   DataValue GetDataValue() const;

--- a/include/opc/ua/node.h
+++ b/include/opc/ua/node.h
@@ -89,6 +89,8 @@ public:
   VariableAccessLevel GetAccessLevel() const { return static_cast<VariableAccessLevel>(GetAttribute(AttributeId::AccessLevel).Value.As<uint8_t>()); }
   void SetDescription(const LocalizedText & value) { SetAttribute(AttributeId::Description, DataValue(value)); }
   LocalizedText GetDescription() const { return GetAttribute(AttributeId::Description).Value.As<LocalizedText>(); }
+  void SetNodeClass(NodeClass value) { SetAttribute(AttributeId::NodeClass, DataValue(static_cast<int32_t>(value))); }
+  NodeClass GetNodeClass() const { return static_cast<NodeClass>(GetAttribute(AttributeId::NodeClass).Value.As<int32_t>()); }
   void SetUserAccessLevel(VariableAccessLevel value) { SetAttribute(AttributeId::UserAccessLevel, DataValue(static_cast<uint8_t>(value))); }
   VariableAccessLevel GetUserAccessLevel() const { return static_cast<VariableAccessLevel>(GetAttribute(AttributeId::UserAccessLevel).Value.As<uint8_t>()); }
   void SetUserWriteMask(AttributeWriteMask value) { SetAttribute(AttributeId::UserWriteMask, DataValue(static_cast<uint32_t>(value))); }

--- a/include/opc/ua/protocol/nodeid.h
+++ b/include/opc/ua/protocol/nodeid.h
@@ -42,7 +42,7 @@ enum NodeIdEncoding : uint8_t
 struct ExpandedNodeId;
 
 struct NodeId
-{
+  {
   NodeIdEncoding Encoding;
   std::string NamespaceURI;
   uint32_t ServerIndex;

--- a/include/opc/ua/protocol/variable_access_level.h
+++ b/include/opc/ua/protocol/variable_access_level.h
@@ -23,6 +23,8 @@ enum class VariableAccessLevel : uint8_t
   HistoryWrite = 8,
   SemanticChange = 16,
 };
+inline VariableAccessLevel operator|(VariableAccessLevel a, VariableAccessLevel b) { return static_cast<VariableAccessLevel>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b)); }
+inline VariableAccessLevel operator&(VariableAccessLevel a, VariableAccessLevel b) { return static_cast<VariableAccessLevel>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b)); }
 }
 
 #endif /* OPC_UA_VARIABLE_ACCESS_LEVEL_H_ */

--- a/src/core/node.cpp
+++ b/src/core/node.cpp
@@ -177,6 +177,9 @@ void Node::_GetChildren(const ReferenceId & refid, std::vector<Node>& nodes) con
 
 Node Node::GetParent() const
 {
+  if (!Server) {
+    return Node();
+  }
   BrowseDescription description;
   description.NodeToBrowse = Id;
   description.Direction = BrowseDirection::Inverse;
@@ -289,9 +292,13 @@ std::vector<Node> Node::GetProperties() const
 {
   std::vector<Node> result;
   _GetChildren(OpcUa::ReferenceId::HasProperty, result);
+  if (GetNodeClass() != NodeClass::ObjectType)
+    {
+      return result;
+    }
   Node parent = GetParent();
   while (!parent.GetId().IsNull()) {
-    if (parent.GetAttribute(AttributeId::NodeClass).Value.As<int32_t>() != static_cast<int32_t>(NodeClass::ObjectType))
+    if (parent.GetNodeClass() != NodeClass::ObjectType)
       {
         return result;
       }

--- a/src/core/node.cpp
+++ b/src/core/node.cpp
@@ -415,8 +415,12 @@ Node Node::AddVariable(const NodeId & nodeid, const QualifiedName & browsename, 
   VariableAttributes attr;
   attr.DisplayName = LocalizedText(browsename.Name);
   attr.Description = LocalizedText(browsename.Name);
+
+  // this seems to be invalid - for WriteMask we have to use
+  // OpcUa::AttributeWriteMask enum
   attr.WriteMask = (uint32_t)OpenFileMode::Read;
   attr.UserWriteMask = (uint32_t)OpenFileMode::Read;
+
   attr.Value = val;
   attr.Type = datatype;
   attr.Rank  = -1;


### PR DESCRIPTION
As far as I can see this PR fixes the issues which have been introduced to Node::getProperties() by my last PR. Can you have a look at it?

It was not - as described here: [https://github.com/FreeOpcUa/freeopcua/pull/262#issuecomment-327731802]() that you always got all properties of all parents, because even the old implementation only recursed parents with NodeClass::ObjectType. But children of ObjectType nodes "inherited" properties even when they were no ObjectType node by themselves - this was clearly wrong.

The PR completely limits the inheritance to ObjectType nodes. As far as I understand the node tree this should solve the problem and give an intuitive user experience.  So now - please drop bombs on me ;)

BTW: there is initialization of WriteMask and UserWriteMask in node.cpp line 417 (I set a comment at that - so you can see it in this diff) that seems wrong to me ... could someone please have a look at that too. Thanks.