### PR TITLE
allow multiple instances when using classic debug interface

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -106,7 +106,11 @@ void KeepAliveThread::Stop()
 UaClient::UaClient(bool debug)
   : KeepAlive(nullptr)
 {
-  Logger = spdlog::stderr_color_mt("UaClient");
+  Logger = spdlog::get("UaClient");
+  if (!Logger)
+    {
+      Logger = spdlog::stderr_color_mt("UaClient");
+    }
   if (debug)
     {
       Logger->set_level(spdlog::level::debug);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -33,7 +33,11 @@ UaServer::UaServer()
 
 UaServer::UaServer(bool debug)
 {
-  Logger = spdlog::stderr_color_mt("UaServer");
+  Logger = spdlog::get("UaServer");
+  if (!Logger)
+  {
+    Logger = spdlog::stderr_color_mt("UaServer");
+  }
   if (debug)
     {
       Logger->set_level(spdlog::level::debug);


### PR DESCRIPTION
When intruducing spdlog I tried to keep the external interface
compatible with the old style debug approach.

For multiple instances of clients or servers this failed, as spdlog
keeps track of the names of instanciated loggers and denies to create
duplicate logger names. To allow to use the classic interface with
multiple instances, check if there already is a logger with the name
we want to create.