### PR TITLE
Silence compiler warnings

### DIFF
--- a/include/opc/spdlog/details/mpmc_bounded_q.h
+++ b/include/opc/spdlog/details/mpmc_bounded_q.h
@@ -88,7 +88,7 @@ public:
         {
             cell = &buffer_[pos & buffer_mask_];
             size_t seq = cell->sequence_.load(std::memory_order_acquire);
-            intptr_t dif = (intptr_t)seq - (intptr_t)pos;
+            intptr_t dif = static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
             if (dif == 0)
             {
                 if (enqueue_pos_.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
@@ -117,7 +117,7 @@ public:
             cell = &buffer_[pos & buffer_mask_];
             size_t seq =
                 cell->sequence_.load(std::memory_order_acquire);
-            intptr_t dif = (intptr_t)seq - (intptr_t)(pos + 1);
+            intptr_t dif = static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos + 1);
             if (dif == 0)
             {
                 if (dequeue_pos_.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))

--- a/include/opc/ua/protocol/string_utils.h
+++ b/include/opc/ua/protocol/string_utils.h
@@ -21,6 +21,7 @@
 
 #include <opc/ua/protocol/attribute_ids.h>
 #include <opc/ua/protocol/types.h>
+#include <opc/ua/protocol/utils.h>
 #include <opc/ua/protocol/view.h>
 #include <ostream>
 #include <limits>
@@ -71,31 +72,9 @@ inline std::ostream & operator<<(std::ostream & os, const OpcUa::Guid & guid)
   return os;
 }
 
-inline std::ostream & operator<<(std::ostream & os, const OpcUa::ByteString & buf)
+inline std::ostream & operator<<(std::ostream & os, const OpcUa::ByteString & value)
 {
-  const std::size_t size = buf.Data.size();
-  unsigned pos = 0;
-  os << "Data size: " << size << std::endl;
-
-  while (pos < size)
-    {
-      if (pos)
-        { printf((pos % 16 == 0) ? "\n" : " "); }
-
-      const char letter = buf.Data[pos];
-      printf("%02x", (unsigned)letter & 0x000000FF);
-
-      if (letter > ' ')
-        { os << "(" << letter << ")"; }
-
-      else
-        { os << "   "; }
-
-      ++pos;
-    }
-
-  os << std::endl;
-  return os;
+  return ToHexDump(os, value.Data);
 }
 }
 

--- a/include/opc/ua/protocol/utils.h
+++ b/include/opc/ua/protocol/utils.h
@@ -61,39 +61,50 @@ inline std::string ToHexDump(const char * buf, std::size_t size)
   return result.str();
 }
 
-inline std::string ToHexDump(const std::vector<char> & buf, std::size_t size)
+template <typename T> inline std::ostream & ToHexDump(std::ostream & os, const std::vector<T> & buf, std::size_t size)
 {
-  std::stringstream result;
   std::stringstream lineEnd;
   size = std::min(size, buf.size());
   unsigned pos = 0;
-  result << "size: " << size << "(0x" << std::hex << size << ")";
+  os << "size: " << size << "(0x" << std::hex << size << ")";
 
   while (pos < size)
     {
       if ((pos % 16) == 0)
         {
-          result << std::endl << std::setfill('0') << std::setw(4) << (pos & 0xFFFF);
+          os << std::endl << std::setfill('0') << std::setw(4) << (pos & 0xFFFF);
           lineEnd.str(std::string());
         }
       if ((pos % 8) == 0)
         {
-          result << " ";
+          os << " ";
           lineEnd << " ";
         }
 
       const char c = buf[pos];
-      result << " " << std::setw(2) << (c & 0xFF);
+      os << " " << std::setw(2) << (c & 0xFF);
       lineEnd << ((c > ' ' && c < 0x7f) ? c : '.');
 
       if ((pos % 16) == 15)
         {
-          result << " " << lineEnd.str();
+          os << " " << lineEnd.str();
         }
       ++pos;
     }
 
-  result << std::endl << std::flush;
+  os << std::endl;
+  return os;
+}
+
+template <typename T> inline std::ostream & ToHexDump(std::ostream & os, const std::vector<T> & buf)
+{
+    return ToHexDump(os, buf, buf.size());
+}
+
+inline std::string ToHexDump(const std::vector<char> & buf, std::size_t size)
+{
+  std::stringstream result;
+  ToHexDump(result, buf, size);
   return result.str();
 }
 

--- a/src/server/server_object.cpp
+++ b/src/server/server_object.cpp
@@ -56,7 +56,7 @@ namespace Server
 
 ServerObject::ServerObject(Services::SharedPtr services, boost::asio::io_service & io, bool debug)
   : Server(services)
-  , Io(io)
+//  , Io(io)
   , Debug(debug)
   , Instance(CreateServerObject(services))
   , ServerTime(Instance.GetVariable(GetCurrentTimeRelativepath()))

--- a/src/server/server_object.h
+++ b/src/server/server_object.h
@@ -52,7 +52,7 @@ private:
 
 private:
   Services::SharedPtr Server;
-  boost::asio::io_service & Io;
+//  boost::asio::io_service & Io;
   bool Debug = false;
   Model::Object Instance;
   Model::Variable ServerTime;

--- a/tests/protocol/binary_serialize_variant.cpp
+++ b/tests/protocol/binary_serialize_variant.cpp
@@ -1231,7 +1231,7 @@ TEST_F(OpcUaBinaryDeserialization, Variant_STRING_Array)
   Variant var;
   GetStream() >> var;
 
-  OpcUa::Guid guid = CreateTestGuid();
+//  OpcUa::Guid guid = CreateTestGuid();
 
   ASSERT_EQ(var.Type(), VariantType::STRING);
   std::vector<std::string> vals;
@@ -1265,7 +1265,7 @@ TEST_F(OpcUaBinaryDeserialization, Variant_STRING_DIMENSIONS)
   Variant var;
   GetStream() >> var;
 
-  OpcUa::Guid guid = CreateTestGuid();
+//  OpcUa::Guid guid = CreateTestGuid();
 
   ASSERT_EQ(var.Type(), VariantType::STRING);
   ASSERT_EQ(var.As<std::string>(), std::string("Root"));
@@ -1353,7 +1353,7 @@ TEST_F(OpcUaBinaryDeserialization, Variant_BYTE_STRING_DIMENSIONS)
   Variant var;
   GetStream() >> var;
 
-  OpcUa::Guid guid = CreateTestGuid();
+//  OpcUa::Guid guid = CreateTestGuid();
 
   ASSERT_EQ(var.Type(), VariantType::BYTE_STRING);
   ASSERT_EQ(var.As<ByteString>(), ByteString(std::vector<uint8_t> {1, 2}));


### PR DESCRIPTION
Silence compiler warnings and fix invalid output of OpcUa::ByteString to std::ostream