### PR TITLE
Necessary changes to compile in visual studio 2013 and windows 10.

### DIFF
--- a/include/opc/ua/protocol/utils.h
+++ b/include/opc/ua/protocol/utils.h
@@ -64,7 +64,7 @@ inline std::string ToHexDump(const char * buf, std::size_t size)
 template <typename T> inline std::ostream & ToHexDump(std::ostream & os, const std::vector<T> & buf, std::size_t size)
 {
   std::stringstream lineEnd;
-  size = std::min(size, buf.size());
+  size = (std::min)(size, buf.size());
   unsigned pos = 0;
   os << "size: " << size << "(0x" << std::hex << size << ")";
 

--- a/src/protocol/binary_stream.cpp
+++ b/src/protocol/binary_stream.cpp
@@ -523,7 +523,7 @@ void DataDeserializer::Deserialize<ByteString>(ByteString & value)
   uint32_t stringSize = 0;
   *this >> stringSize;
 
-  if (stringSize != ~uint32_t())
+  if (stringSize != ~uint32_t() && stringSize > 0)
     {
       value.Data.resize(stringSize);
       GetData(In, reinterpret_cast<char *>(&value.Data[0]), stringSize);

--- a/src/protocol/binary_variant.cpp
+++ b/src/protocol/binary_variant.cpp
@@ -1061,13 +1061,17 @@ void DataDeserializer::Deserialize<Variant>(Variant & var)
     { var = deserializer.get<DiagnosticInfo>(); }
 
   else if (encodingMask == ((uint8_t)VariantType::DIAGNOSTIC_INFO | HAS_ARRAY_MASK))
-    { var = deserializer.get<std::vector<DiagnosticInfo>>(); }
+  {
+	  var = deserializer.get<DiagnosticInfoList>();
+  }
 
   else if (encodingMask == ((uint8_t)VariantType::EXTENSION_OBJECT))
     { var = deserializer.get<ExtensionObject>(); }
 
   else if (encodingMask == ((uint8_t)VariantType::EXTENSION_OBJECT | HAS_ARRAY_MASK))
-    { var = deserializer.get<std::vector<ExtensionObject>>(); }
+  {
+	  var = deserializer.get<std::vector<OpcUa::ExtensionObject>>();
+  }
 
   else
     { throw std::logic_error("Deserialization of VariantType: " + std::to_string(encodingMask) + " is not supported yet."); }

--- a/src/protocol/deserialize_auto.cpp
+++ b/src/protocol/deserialize_auto.cpp
@@ -328,12 +328,18 @@ void DataDeserializer::Deserialize<XmlElement>(XmlElement & data)
 */
 
 template<>
-void DataDeserializer::Deserialize<ExtensionObject>(ExtensionObject & data)
+void DataDeserializer::Deserialize<OpcUa::ExtensionObject>(OpcUa::ExtensionObject & data)
 {
   *this >> data.TypeId;
   *this >> data.Encoding;
 
   if ((data.Encoding) & (1 >> (0))) { *this >> data.Body; }
+}
+
+template<>
+void DataDeserializer::Deserialize<std::vector<OpcUa::ExtensionObject>>(std::vector<OpcUa::ExtensionObject> & infos)
+{
+	DeserializeContainer(*this, infos);
 }
 
 

--- a/src/server/tcp_server.cpp
+++ b/src/server/tcp_server.cpp
@@ -9,6 +9,7 @@
 ///
 
 #ifdef _WIN32
+#include <WinSock2.h>
 #include <windows.h>
 #endif
 
@@ -178,7 +179,7 @@ public:
       {
         LOG_INFO(Logger, "shutting down opc ua binary server");
         Stopped = true;
-        shutdown(Socket, SHUT_RDWR);
+		shutdown(Socket, SD_BOTH/*SHUT_RDWR*/);
         ServerThread->Join();
         ServerThread.reset();
       }


### PR DESCRIPTION
DataDeserializer::Deserialize<ByteString>(ByteString & value): if stringSize is 0 crash in line 529