### PR TITLE
Fix handling of ArrayDimensions in Variant

### DIFF
--- a/include/opc/ua/protocol/variant.h
+++ b/include/opc/ua/protocol/variant.h
@@ -165,6 +165,7 @@ public:
   Variant() {}
   Variant(const Variant & var)
     : Value(var.Value)
+    , Dimensions(var.Dimensions)
   {
   }
 
@@ -180,6 +181,7 @@ public:
   Variant & operator= (const Variant & variant)
   {
     this->Value = variant.Value;
+    this->Dimensions = variant.Dimensions;
     return *this;
   }
 


### PR DESCRIPTION
With the current implementation, reading multi-dimensional values
does not work as expected, the ArrayDimensions information is missing.
This is caused by the Dimensions vector being ignored when creating
a Variant from another Variant.

This patch fixes the issue by copying the Dimensions vector in
Variant(const Variant &) and operator=(const Variant &).