### PR TITLE
Changed AddDataChangeCallback to mirror python-opcua implementation

### DIFF
--- a/include/opc/ua/server/address_space.h
+++ b/include/opc/ua/server/address_space.h
@@ -35,7 +35,7 @@ public:
   DEFINE_CLASS_POINTERS(AddressSpace)
 
   //Server side methods
-  virtual uint32_t AddDataChangeCallback(const NodeId & node, AttributeId attribute, std::function<DataChangeCallback> callback) = 0;
+  virtual std::pair<StatusCode,uint32_t> AddDataChangeCallback(const NodeId & node, AttributeId attribute, std::function<DataChangeCallback> callback) = 0;
   virtual void DeleteDataChangeCallback(uint32_t clienthandle) = 0;
   virtual StatusCode SetValueCallback(const NodeId & node, AttributeId attribute, std::function<DataValue(void)> callback) = 0;
   virtual void SetMethod(const NodeId & node, std::function<std::vector<OpcUa::Variant> (NodeId context, std::vector<OpcUa::Variant> arguments)> callback) = 0;

--- a/python/src/py_opcua_module.cpp
+++ b/python/src/py_opcua_module.cpp
@@ -242,7 +242,7 @@ static void Node_SetValue(Node & self, const object & obj, VariantType vtype)
 // UaClient helpers
 //--------------------------------------------------------------------------
 
-static std::shared_ptr<Subscription> UaClient_CreateSubscription(UaClient & self, uint period, PySubscriptionHandler & callback)
+static std::shared_ptr<Subscription> UaClient_CreateSubscription(UaClient & self, uint32_t period, PySubscriptionHandler & callback)
 {
   return self.CreateSubscription(period, callback);
 }
@@ -256,7 +256,7 @@ static Node UaClient_GetNode(UaClient & self, ObjectId objectid)
 // UaServer helpers
 //--------------------------------------------------------------------------
 
-static std::shared_ptr<Subscription> UaServer_CreateSubscription(UaServer & self, uint period, PySubscriptionHandler & callback)
+static std::shared_ptr<Subscription> UaServer_CreateSubscription(UaServer & self, uint32_t period, PySubscriptionHandler & callback)
 {
   return self.CreateSubscription(period, callback);
 }

--- a/src/core/common/uri_facade_win.cpp
+++ b/src/core/common/uri_facade_win.cpp
@@ -19,7 +19,7 @@
 namespace Common
 {
 
-void Uri::Initialize(const char * uriString, std::size_t size)
+void Uri::Initialize(const std::string & uriString)
 {
   URL_COMPONENTS url = {0};
   url.dwStructSize = sizeof(url);
@@ -31,7 +31,7 @@ void Uri::Initialize(const char * uriString, std::size_t size)
 
   // TODO msdn says do not use this function in services and in server patforms. :(
   // TODO http://msdn.microsoft.com/en-us/library/windows/desktop/aa384376(v=vs.85).aspx
-  if (!InternetCrackUrl(uriString, size, options, &url))
+  if (!InternetCrackUrl(uriString.c_str(), uriString.size(), options, &url))
     {
       THROW_ERROR1(CannotParseUri, uriString);
     }

--- a/src/server/address_space_addon.cpp
+++ b/src/server/address_space_addon.cpp
@@ -94,7 +94,7 @@ std::vector<StatusCode> AddressSpaceAddon::Write(const std::vector<OpcUa::WriteV
   return Registry->Write(filter);
 }
 
-uint32_t AddressSpaceAddon::AddDataChangeCallback(const NodeId & node, AttributeId attribute, std::function<Server::DataChangeCallback> callback)
+std::pair<StatusCode,uint32_t> AddressSpaceAddon::AddDataChangeCallback(const NodeId & node, AttributeId attribute, std::function<Server::DataChangeCallback> callback)
 {
   return Registry->AddDataChangeCallback(node, attribute, callback);
 }

--- a/src/server/address_space_addon.h
+++ b/src/server/address_space_addon.h
@@ -56,7 +56,7 @@ public: // MethodServices
   virtual std::vector<CallMethodResult> Call(const std::vector<CallMethodRequest> & methodsToCall);
 
 public: // Server internal methods
-  virtual uint32_t AddDataChangeCallback(const NodeId & node, AttributeId attribute, std::function<Server::DataChangeCallback> callback);
+  virtual std::pair<StatusCode,uint32_t> AddDataChangeCallback(const NodeId & node, AttributeId attribute, std::function<Server::DataChangeCallback> callback);
   virtual void DeleteDataChangeCallback(uint32_t clienthandle);
   virtual StatusCode SetValueCallback(const NodeId & node, AttributeId attribute, std::function<DataValue(void)> callback);
   virtual void SetMethod(const NodeId & node, std::function<std::vector<OpcUa::Variant> (NodeId context, std::vector<OpcUa::Variant> arguments)> callback);

--- a/src/server/address_space_internal.h
+++ b/src/server/address_space_internal.h
@@ -100,7 +100,7 @@ public:
 
   /// @brief Add callback which will be called when values of attribute is changed.
   /// @return handle of a callback which should be passed to the DeletDataChangeCallabck
-  uint32_t AddDataChangeCallback(const NodeId & node, AttributeId attribute, std::function<Server::DataChangeCallback> callback);
+  std::pair<StatusCode,uint32_t> AddDataChangeCallback(const NodeId & node, AttributeId attribute, std::function<Server::DataChangeCallback> callback);
 
   /// @bried Delete data change callback assosioated with handle.
   void DeleteDataChangeCallback(uint32_t serverhandle);

--- a/src/server/internal_subscription.cpp
+++ b/src/server/internal_subscription.cpp
@@ -305,10 +305,18 @@ MonitoredItemCreateResult InternalSubscription::CreateMonitoredItem(const Monito
       LOG_DEBUG(Logger, "internal_subscription | id: {}, subscribe to data changes", Data.SubscriptionId);
 
       uint32_t id = result.MonitoredItemId;
-      callbackHandle = AddressSpace.AddDataChangeCallback(request.ItemToMonitor.NodeId, request.ItemToMonitor.AttributeId, [this, id](const OpcUa::NodeId & nodeId, OpcUa::AttributeId attr, const DataValue & value)
+      std::pair<OpcUa::StatusCode,uint32_t> addCallbackResult = AddressSpace.AddDataChangeCallback(request.ItemToMonitor.NodeId, request.ItemToMonitor.AttributeId, [this, id](const OpcUa::NodeId & nodeId, OpcUa::AttributeId attr, const DataValue & value)
       {
         this->DataChangeCallback(id, value);
       });
+
+      result.Status = addCallbackResult.first;
+      callbackHandle = addCallbackResult.second;
+
+      if (result.Status != StatusCode::Good) 
+        {
+          return result;
+        }
     }
 
   MonitoredDataChange mdata;

--- a/src/server/tcp_server.cpp
+++ b/src/server/tcp_server.cpp
@@ -9,7 +9,10 @@
 ///
 
 #ifdef _WIN32
+#define NOMINMAX
+#include <WinSock2.h>
 #include <windows.h>
+#define SHUT_RDWR SD_BOTH
 #endif
 
 #include "tcp_server.h"

--- a/tests/server/address_space_ut.cpp
+++ b/tests/server/address_space_ut.cpp
@@ -106,13 +106,15 @@ TEST_F(AddressSpace, CallsDataChangeCallbackOnWrite)
   OpcUa::AttributeId callbackAttr;
   OpcUa::DataValue callbackValue;
   bool callbackCalled = false;
-  unsigned callbackHandle = NameSpace->AddDataChangeCallback(valueId, OpcUa::AttributeId::Value, [&](const OpcUa::NodeId & id, OpcUa::AttributeId attr, const OpcUa::DataValue & value)
+  std::pair<OpcUa::StatusCode,uint32_t> addCallbackResult = NameSpace->AddDataChangeCallback(valueId, OpcUa::AttributeId::Value, [&](const OpcUa::NodeId & id, OpcUa::AttributeId attr, const OpcUa::DataValue & value)
   {
     callbackId = id;
     callbackAttr = attr;
     callbackValue = value;
     callbackCalled = true;
   });
+
+  unsigned callbackHandle = addCallbackResult.second;
 
   EXPECT_NE(callbackHandle, 0);
 

--- a/tests/server/model_object_ut.cpp
+++ b/tests/server/model_object_ut.cpp
@@ -34,6 +34,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#ifdef _WIN32
+#undef GetObject
+#endif
+
 using namespace testing;
 
 


### PR DESCRIPTION
The AddDataChangeCallback function was changed to return a OPC UA status code to indicate if adding the callback was successful. The exception that was thrown from AddDataChangeCallback when adding a callback failed triggered a goodbye message to be sent to the connecting client when they were attempting to create a monitored item. This fix should make connecting clients receive the proper OPC UA status code instead.