### PR TITLE
#292 Update travis.yml to current CI environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,10 @@
 language: cpp
 compiler: gcc
 
-before_install:
-  # We need this line to have g++4.8 available in apt
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo add-apt-repository -y ppa:boost-latest/ppa
-  - sudo apt-get update -qq
-
 install:
   - sudo apt-get install libboost1.54-all-dev -qq
   - sudo apt-get install libboost-python1.54-dev -qq
-  - sudo apt-get install -qq gcc-4.8 g++-4.8 
   - sudo apt-get install libcppunit-dev
-  # We want to compile with g++ 4.8 when rather than the default g++
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
 
 #script: autoreconf -f -i && ./configure --disable-python-bindings && make && make check
 script: autoreconf -f -i && ./configure && make && make check


### PR DESCRIPTION
Remove specific installation for GCC-4.8 and repository for Boost-1.54

These are all available in the current travis environment