### PR TITLE
Closing socket correctly.

### DIFF
--- a/src/core/socket_channel.cpp
+++ b/src/core/socket_channel.cpp
@@ -50,12 +50,7 @@ OpcUa::SocketChannel::~SocketChannel()
 
 void OpcUa::SocketChannel::Stop()
 {
-  int error = shutdown(Socket, 2);
-
-  if (error < 0)
-    {
-      std::cerr << "Failed to close socket connection. " << strerror(errno) << std::endl;
-    }
+  close(Socket);
 }
 
 std::size_t OpcUa::SocketChannel::Receive(char * data, std::size_t size)


### PR DESCRIPTION
Added  a fix for this issue: https://github.com/FreeOpcUa/freeopcua/issues/296
It removes the message "Failed to close socket connection. Transport endpoint is not connected" and it allows one to repeatedly use client.Connect() and client.Disconnect() since the sockets gets closed correctly now.
