### PR TITLE
Bug fixes for Windows and the OPC UA server

### DIFF
--- a/include/opc/ua/protocol/input_from_stream_buffer.h
+++ b/include/opc/ua/protocol/input_from_stream_buffer.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *   Copyright (C) 2013-2014 by Alexander Rykovanov                        *
+ *   rykovanov.as@gmail.com                                                   *
+ *                                                                            *
+ *   This library is free software; you can redistribute it and/or modify     *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation; version 3 of the License.     *
+ *                                                                            *
+ *   This library is distributed in the hope that it will be useful,          *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public License *
+ *   along with this library; if not, write to the                            *
+ *   Free Software Foundation, Inc.,                                          *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.                *
+ ******************************************************************************/
+
+#pragma once
+
+#include <opc/ua/protocol/channel.h>
+#include <boost/asio/streambuf.hpp>
+
+namespace OpcUa
+{
+
+class InputFromStreamBuffer : public OpcUa::InputChannel
+{
+public:
+  InputFromStreamBuffer(boost::asio::streambuf & buf);
+
+  virtual std::size_t Receive(char * data, std::size_t size) override;
+
+  size_t GetRemainSize() const;
+
+  virtual void Stop() override {}
+
+private:
+		boost::asio::streambuf & Buffer;
+};
+
+}

--- a/include/opc/ua/protocol/status_codes.h
+++ b/include/opc/ua/protocol/status_codes.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdexcept>
 
 namespace OpcUa
 {
@@ -232,6 +233,14 @@ enum class StatusCode : uint32_t
 
 //raise appropriate exception if StatusCode is not Good
 void CheckStatusCode(StatusCode code);
+
+class StatusCodeException : public std::runtime_error {
+public:
+	explicit StatusCodeException(StatusCode value);
+	StatusCode GetValue() const;
+private:
+	StatusCode Value;
+};
 
 }
 

--- a/python/src/py_opcua_module.cpp
+++ b/python/src/py_opcua_module.cpp
@@ -242,7 +242,7 @@ static void Node_SetValue(Node & self, const object & obj, VariantType vtype)
 // UaClient helpers
 //--------------------------------------------------------------------------
 
-static std::shared_ptr<Subscription> UaClient_CreateSubscription(UaClient & self, uint period, PySubscriptionHandler & callback)
+static std::shared_ptr<Subscription> UaClient_CreateSubscription(UaClient & self, uint32_t period, PySubscriptionHandler & callback)
 {
   return self.CreateSubscription(period, callback);
 }
@@ -256,7 +256,7 @@ static Node UaClient_GetNode(UaClient & self, ObjectId objectid)
 // UaServer helpers
 //--------------------------------------------------------------------------
 
-static std::shared_ptr<Subscription> UaServer_CreateSubscription(UaServer & self, uint period, PySubscriptionHandler & callback)
+static std::shared_ptr<Subscription> UaServer_CreateSubscription(UaServer & self, uint32_t period, PySubscriptionHandler & callback)
 {
   return self.CreateSubscription(period, callback);
 }

--- a/src/core/common/uri_facade_win.cpp
+++ b/src/core/common/uri_facade_win.cpp
@@ -7,48 +7,4 @@
 /// (See accompanying file LICENSE or copy at
 /// http://www.gnu.org/licenses/lgpl.html)
 ///
-
-
-#include <windows.h>
-#include <wininet.h>
-
-#include <opc/common/uri_facade.h>
-#include <opc/common/exception.h>
-
-
-namespace Common
-{
-
-void Uri::Initialize(const char * uriString, std::size_t size)
-{
-  URL_COMPONENTS url = {0};
-  url.dwStructSize = sizeof(url);
-  url.dwSchemeLength = 1;
-  url.dwUserNameLength = 1;
-  url.dwPasswordLength = 1;
-  url.dwHostNameLength = 1;
-  DWORD options = 0;
-
-  // TODO msdn says do not use this function in services and in server patforms. :(
-  // TODO http://msdn.microsoft.com/en-us/library/windows/desktop/aa384376(v=vs.85).aspx
-  if (!InternetCrackUrl(uriString, size, options, &url))
-    {
-      THROW_ERROR1(CannotParseUri, uriString);
-    }
-
-
-  SchemeStr = std::string(url.lpszScheme, url.lpszScheme + url.dwSchemeLength);
-  UserStr = std::string(url.lpszUserName, url.lpszUserName + url.dwUserNameLength);
-  PasswordStr = std::string(url.lpszPassword, url.lpszPassword + url.dwPasswordLength);
-  HostStr = std::string(url.lpszHostName, url.lpszHostName + url.dwHostNameLength);
-  PortNum = url.nPort;
-
-  if (SchemeStr.empty() || HostStr.empty())
-    {
-      THROW_ERROR1(CannotParseUri, uriString);
-    }
-}
-
-} // namespace Common
-
-
+#include "uri_facade_lin.cpp" 

--- a/src/protocol/input_from_stream_buffer.cpp
+++ b/src/protocol/input_from_stream_buffer.cpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+ *   This library is free software; you can redistribute it and/or modify     *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation; version 3 of the License.     *
+ *                                                                            *
+ *   This library is distributed in the hope that it will be useful,          *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public License *
+ *   along with this library; if not, write to the                            *
+ *   Free Software Foundation, Inc.,                                          *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.                *
+ ******************************************************************************/
+
+#include <opc/ua/protocol/input_from_stream_buffer.h>
+
+#include <algorithm>
+
+namespace OpcUa
+{
+
+InputFromStreamBuffer::InputFromStreamBuffer(boost::asio::streambuf & buf) : Buffer(buf) 
+{
+
+}
+
+std::size_t InputFromStreamBuffer::Receive(char * data, std::size_t size)
+{
+  size_t bufferSize = GetRemainSize();
+  if (bufferSize == 0)
+  {
+    return 0;
+  }
+
+  const std::size_t sizeToRead = std::min(bufferSize, size);
+  Buffer.sgetn(data, sizeToRead);
+  return sizeToRead;
+}
+
+size_t InputFromStreamBuffer::GetRemainSize() const {
+  return Buffer.size();
+}
+
+}

--- a/src/protocol/status_codes.cpp
+++ b/src/protocol/status_codes.cpp
@@ -19,7 +19,13 @@ void OpcUa::CheckStatusCode(StatusCode code)
   if (code == StatusCode::Good)
     { return; }
 
-  throw std::runtime_error(OpcUa::ToString(code));
+  throw StatusCodeException(code);
 }
 
+OpcUa::StatusCodeException::StatusCodeException(StatusCode value) : runtime_error(OpcUa::ToString(value)), Value(value) {
 
+}
+
+OpcUa::StatusCode OpcUa::StatusCodeException::GetValue() const {
+	return Value;
+}

--- a/src/server/address_space_internal.cpp
+++ b/src/server/address_space_internal.cpp
@@ -283,7 +283,7 @@ uint32_t AddressSpaceInMemory::AddDataChangeCallback(const NodeId & node, Attrib
   if (it == Nodes.end())
     {
       LOG_ERROR(Logger, "address_space_internal| Node: '{}' not found", node);
-      throw std::runtime_error("address_space_internal| NodeId not found");
+	  throw StatusCodeException(StatusCode::BadNodeIdUnknown);
     }
 
   AttributesMap::iterator ait = it->second.Attributes.find(attribute);
@@ -291,7 +291,7 @@ uint32_t AddressSpaceInMemory::AddDataChangeCallback(const NodeId & node, Attrib
   if (ait == it->second.Attributes.end())
     {
       LOG_ERROR(Logger, "address_space_internal| Attribute: {} of node: ‘{}‘ not found", (unsigned)attribute, node);
-      throw std::runtime_error("Attribute not found");
+	  throw StatusCodeException(StatusCode::BadAttributeIdInvalid);
     }
 
   uint32_t handle = ++DataChangeCallbackHandle;

--- a/src/server/internal_subscription.cpp
+++ b/src/server/internal_subscription.cpp
@@ -303,12 +303,17 @@ MonitoredItemCreateResult InternalSubscription::CreateMonitoredItem(const Monito
   if (request.ItemToMonitor.AttributeId != AttributeId::EventNotifier)
     {
       LOG_DEBUG(Logger, "internal_subscription | id: {}, subscribe to data changes", Data.SubscriptionId);
-
+	  
       uint32_t id = result.MonitoredItemId;
-      callbackHandle = AddressSpace.AddDataChangeCallback(request.ItemToMonitor.NodeId, request.ItemToMonitor.AttributeId, [this, id](const OpcUa::NodeId & nodeId, OpcUa::AttributeId attr, const DataValue & value)
-      {
-        this->DataChangeCallback(id, value);
-      });
+      try {
+        callbackHandle = AddressSpace.AddDataChangeCallback(request.ItemToMonitor.NodeId, request.ItemToMonitor.AttributeId, [this, id](const OpcUa::NodeId & nodeId, OpcUa::AttributeId attr, const DataValue & value)
+        {
+          this->DataChangeCallback(id, value);
+        });
+      } catch (StatusCodeException e){
+        result.Status = e.GetValue();
+        return result;
+      }
     }
 
   MonitoredDataChange mdata;

--- a/src/server/server_object.cpp
+++ b/src/server/server_object.cpp
@@ -25,7 +25,7 @@
 #include <functional>
 #include <iostream>
 
-#ifdef WIN32
+#ifdef _WIN32
 #undef GetObject
 #endif
 

--- a/src/server/tcp_server.cpp
+++ b/src/server/tcp_server.cpp
@@ -9,7 +9,10 @@
 ///
 
 #ifdef _WIN32
+#define NOMINMAX
+#include <WinSock2.h>
 #include <windows.h>
+#define SHUT_RDWR SD_BOTH
 #endif
 
 #include "tcp_server.h"


### PR DESCRIPTION
This pull request should fix the following issues:

- Some Windows specific build errors (ex. #311)

- Issue #193 where large requests could not fit in the servers buffer.

- The issue described in the following closed pull request #293 where clients were disconnected from the server when trying to monitor a non existing item.
