### PR TITLE
Password encryption strategy

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -281,7 +281,12 @@ void UaClient::Connect(const EndpointDescription & endpoint)
                       {
                         sessionParameters.UserIdentityToken.setPolicyId(token.PolicyId);
                         sessionParameters.UserIdentityToken.setUser(user, password);
-                        EncryptPassword(sessionParameters.UserIdentityToken, createSessionResponse);
+
+                        if(token.SecurityPolicyUri != "http://opcfoundation.org/UA/SecurityPolicy#None")
+                        {
+                            EncryptPassword(sessionParameters.UserIdentityToken, createSessionResponse);
+                        }
+
                         user_identify_token_found = true;
                         break;
                       }


### PR DESCRIPTION
Hi all,

for passwd encryption the UserTokenPolicy::SecurityPolicyUri is not interpreted. Passwords will always be encrypted if mbedTLS is enabled. Changed the code to at least consider plaintext passwords if requested by the server.