### PR TITLE
apt clean failes on fresh build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 MAINTAINER Beau Trepp <https://github.com/btrepp>
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get clean && apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade && apt-get install -y \
  gcc \
  g++ \
  make \


### PR DESCRIPTION
Since the cache is empty on first start, apt clean fails.