### PR TITLE
Cast milliseconds to long before constructing a boost::posix_time

### DIFF
--- a/src/server/internal_subscription.cpp
+++ b/src/server/internal_subscription.cpp
@@ -14,7 +14,7 @@ InternalSubscription::InternalSubscription(SubscriptionServiceInternal & service
   , CurrentSession(SessionAuthenticationToken)
   , Callback(callback)
   , io(service.GetIOService())
-  , Timer(io, boost::posix_time::milliseconds(data.RevisedPublishingInterval))
+  , Timer(io, boost::posix_time::milliseconds(static_cast<long>(data.RevisedPublishingInterval)))
   , LifeTimeCount(data.RevisedLifetimeCount)
   , Logger(logger)
 {
@@ -105,7 +105,7 @@ void InternalSubscription::PublishResults(const boost::system::error_code & erro
     }
 
   TimerStopped = false;
-  Timer.expires_at(Timer.expires_at() + boost::posix_time::milliseconds(Data.RevisedPublishingInterval));
+  Timer.expires_at(Timer.expires_at() + boost::posix_time::milliseconds(static_cast<long>(Data.RevisedPublishingInterval)));
   std::shared_ptr<InternalSubscription> self = shared_from_this();
   Timer.async_wait([self](const boost::system::error_code & error) { self->PublishResults(error); });
 }


### PR DESCRIPTION
The constructor of boost::posix_time::milliseconds no longer accepts
floating point numbers but long ints, cast accordingly.

This fixes a compilaton error on Fedora 30.