### PR TITLE
try-catch block added to KeepAliveThread::Run()

### DIFF
--- a/src/core/model_impl.h
+++ b/src/core/model_impl.h
@@ -21,6 +21,8 @@
 
 #include <opc/ua/model.h>
 
+#include <algorithm>
+
 namespace OpcUa
 {
 namespace Model


### PR DESCRIPTION
exception thrown in KeepAliveThread::Run() cannot be caught in client
application and cause app crash when OPC-UA connection is drop. Adding
try-catch block avoid this and gives client app opportunity to create
new OPC-UA connection without crash.