### PR TITLE
Catch exception in client destructor

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -341,7 +341,12 @@ void UaClient::CloseSecureChannel()
 
 UaClient::~UaClient()
 {
-  Disconnect();//Do not leave any thread or connection running
+  try {
+    Disconnect(); // Do not leave any thread or connection running
+  } catch (std::exception &e) {
+    LOG_WARN(Logger,
+             "ua_client             | Failed to disconnect: {}", e.what());
+  }
 }
 
 void UaClient::Disconnect()


### PR DESCRIPTION
The connection may have died when the destructor is called. Catch any
exception and log it.