### PR TITLE
Fix outdated FSF address, replace by URL

### DIFF
--- a/include/opc/ua/global.h
+++ b/include/opc/ua/global.h
@@ -12,9 +12,7 @@
  *   GNU Lesser General Public License for more details.        *
  *                      *
  *   You should have received a copy of the GNU Lesser General Public License *
- *   along with this library; if not, write to the          *
- *   Free Software Foundation, Inc.,              *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.        *
+ *   along with this library. If not, see <https://www.gnu.org/licenses/>.
  ******************************************************************************/
 
 #pragma once

--- a/include/opc/ua/node.h
+++ b/include/opc/ua/node.h
@@ -12,9 +12,7 @@
  *   GNU Lesser General Public License for more details.        *
  *                      *
  *   You should have received a copy of the GNU Lesser General Public License *
- *   along with this library; if not, write to the          *
- *   Free Software Foundation, Inc.,              *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.        *
+ *   along with this library. If not, see <https://www.gnu.org/licenses/>.
  ******************************************************************************/
 
 #pragma once

--- a/include/opc/ua/subscription.h
+++ b/include/opc/ua/subscription.h
@@ -12,9 +12,7 @@
  *   GNU Lesser General Public License for more details.        *
  *                      *
  *   You should have received a copy of the GNU Lesser General Public License *
- *   along with this library; if not, write to the          *
- *   Free Software Foundation, Inc.,              *
- *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.        *
+ *   along with this library. If not, see <https://www.gnu.org/licenses/>.
  ******************************************************************************/
 
 #pragma once


### PR DESCRIPTION
The FSF nowadays just points to the license URL instead of asking to
write them, see https://www.gnu.org/licenses/gpl-howto.html.

This was noticed during review for inclusion in Fedora:
https://bugzilla.redhat.com/show_bug.cgi?id=1824467