### PR TITLE
model_impl.h: add missing <algorithm> include

### DIFF
--- a/src/core/model_impl.h
+++ b/src/core/model_impl.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <opc/ua/model.h>
+#include <algorithm>
 
 namespace OpcUa
 {


### PR DESCRIPTION
A little no-brainer here: The `include <algorithm>` required for `std::for_each` was missing. Fails on my machine with GCC 9.3, might have built successfully for other people due do indirect inclusion who-knows where ;-)