### PR TITLE
Add missing includes to algorithm header

### DIFF
--- a/src/clientapp/opcua_main.cpp
+++ b/src/clientapp/opcua_main.cpp
@@ -20,6 +20,7 @@
 #include <opc/ua/protocol/variant_visitor.h>
 #include <opc/ua/services/services.h>
 
+#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 

--- a/src/core/common/addons_core/config_file.cpp
+++ b/src/core/common/addons_core/config_file.cpp
@@ -16,6 +16,8 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/filesystem.hpp>
+
+#include <algorithm>
 #include <iostream>
 
 using boost::property_tree::ptree;

--- a/src/core/model_impl.h
+++ b/src/core/model_impl.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <opc/ua/model.h>
 
 namespace OpcUa

--- a/src/server/asio_addon.cpp
+++ b/src/server/asio_addon.cpp
@@ -20,6 +20,8 @@
 #include <opc/ua/server/addons/asio_addon.h>
 
 #include <boost/asio.hpp>
+
+#include <algorithm>
 #include <iostream>
 #include <thread>
 


### PR DESCRIPTION
Those were previously pulled in by boost headers, but are not anymore
with boost 1.73, resulting in a build failure.