### PR TITLE
Phoenixdecim/buildfailfix

### DIFF
--- a/debian.soft
+++ b/debian.soft
@@ -1,7 +1,7 @@
 apt-get install gcc g++ make autoconf automake libtool \
 libboost-dev libboost-thread-dev libboost-program-options-dev \
 libboost-system-dev libboost-filesystem-dev \
-libcppunit-dev pkg-config git python-dev libboost-python-dev \
+libcppunit-dev pkg-config git libmbedtls-dev libboost-python-dev \
 gsoap libxml2-dev build-essential autotools-dev dh-make \
 debhelper devscripts fakeroot xutils lintian pbuilder \
 reprepro

--- a/debian.soft
+++ b/debian.soft
@@ -1,8 +1,8 @@
 apt-get install gcc g++ make autoconf automake libtool \
 libboost-dev libboost-thread-dev libboost-program-options-dev \
 libboost-system-dev libboost-filesystem-dev \
-libcppunit-dev pkg-config git libmbedtls-dev libboost-python-dev \
+libcppunit-dev pkg-config git python-dev libboost-python-dev \
 gsoap libxml2-dev build-essential autotools-dev dh-make \
 debhelper devscripts fakeroot xutils lintian pbuilder \
-reprepro
+reprepro libmbedtls-dev
 

--- a/src/server/endpoints_parameters.cpp
+++ b/src/server/endpoints_parameters.cpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <algorithm>
 
 namespace
 {


### PR DESCRIPTION
The current repo is failing to build due to the algorithm header not being included in [endpoint_parameters.cpp](https://github.com/FreeOpcUa/freeopcua/blob/master/src/server/endpoints_parameters.cpp). The mbedTLS library is also a dependency, which is not included in debian.soft. So I have added that as well in [debian.soft](https://github.com/FreeOpcUa/freeopcua/blob/master/debian.soft).