### PR TITLE
Put a link to OPC-UA in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Open Source C++ OPC-UA Server and Client Library
 ========
 [![Build Status](https://travis-ci.org/FreeOpcUa/freeopcua.svg?branch=master)](https://travis-ci.org/FreeOpcUa/freeopcua)
 
-LGPL OPC-UA server and client library written in C++ and with a lot of code auto-generated from xml specification using python.  
+LGPL [OPC-UA](https://opcfoundation.org/about/opc-technologies/opc-ua/) server and client library written in C++ and with a lot of code auto-generated from xml specification using python.  
 
 Python bindings can be found in the python directory.
 


### PR DESCRIPTION
The project description and README do not link to any explanation of OPC-UA. Unless you already know it is hard to find out what this actually is.

I have added a link on the acronym to the official description to mitigate this a bit.