### PR TITLE
Avoid a compiler warning, and while at it hopefully fix the code so that it does what it was supposed to do in the first place

### DIFF
--- a/src/protocol/string_utils.cpp
+++ b/src/protocol/string_utils.cpp
@@ -800,7 +800,7 @@ std::string GetNodeField(const std::string & data, const char * field)
 
   if (semicolon == std::string::npos)
     {
-      data.substr(colon);
+      return data.substr(colon);
     }
 
   return data.substr(colon, semicolon - colon);


### PR DESCRIPTION
Noticed this because the compiler was complaining:
```
warning C4834: discarding return value of function with 'nodiscard' attribute
```

Despite addressing a compiler warning, this PR actually changes behavior, because previously that line has not really done anything... But it does look like this has been the intention here, doesn't it?